### PR TITLE
Feature/configure text

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,9 @@ module.exports = {
     title: `the tiny news collective`,
     siteUrl: `http://www.tinynewsco.org`,
     description: `a local news initiative`,
+    footerTitle: `tinynewsco.org`,
+    footerBylineName: `News Catalyst`,
+    footerBylineLink: `https://newscatalyst.org`
   },
 
   /* Your site config here */

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
   siteMetadata: {
     shortName: `tinynewsco`,
     title: `the tiny news collective`,
-    siteUrl: `http://www.tinynewsco.org`,
+    siteUrl: `/`,
     description: `a local news initiative`,
     footerTitle: `tinynewsco.org`,
     footerBylineName: `News Catalyst`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,6 +13,11 @@ module.exports = {
     footerTitle: `tinynewsco.org`,
     footerBylineName: `News Catalyst`,
     footerBylineLink: `https://newscatalyst.org`,
+    labels: {
+      latestNews: `Latest News`,
+      search: `Search`,
+      topics: `Topics`,
+    },
     nav: {
       articles: `Articles`,
       topics: `Topics`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,11 +8,16 @@ module.exports = {
   siteMetadata: {
     shortName: `tinynewsco`,
     title: `the tiny news collective`,
-    siteUrl: `/`,
+    siteUrl: `https://tinynewsco.org/`,
     description: `a local news initiative`,
     footerTitle: `tinynewsco.org`,
     footerBylineName: `News Catalyst`,
-    footerBylineLink: `https://newscatalyst.org`
+    footerBylineLink: `https://newscatalyst.org`,
+    nav: {
+      articles: `Articles`,
+      topics: `Topics`,
+      cms: `tinycms`
+    }
   },
 
   /* Your site config here */

--- a/src/components/ArticleFooter.js
+++ b/src/components/ArticleFooter.js
@@ -1,12 +1,12 @@
 
 import React from "react"
 
-export default function ArticleFooter() {
+export default function ArticleFooter(props) {
   return (
     <footer className="footer">
       <div className="content has-text-centered">
         <p>
-          <strong>tinynewsco.org</strong> by <a href="https://newscatalyst.org">News Catalyst</a>. 
+          <strong>{props.metadata.footerTitle}</strong> by <a href={props.metadata.footerBylineLink}>{props.metadata.footerBylineName}</a>. 
         </p>
       </div>
     </footer>

--- a/src/components/ArticleNav.js
+++ b/src/components/ArticleNav.js
@@ -4,8 +4,8 @@ export default function ArticleNav(props) {
   return (
     <nav className="navbar" role="navigation" aria-label="main navigation">
       <div className="navbar-brand">
-        <a className="navbar-item" href={props.link}>
-          {props.name}
+        <a className="navbar-item" href={props.metadata.link}>
+          {props.metadata.shortName}
         </a>
 
         <a role="button" className="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">

--- a/src/components/ArticleNav.js
+++ b/src/components/ArticleNav.js
@@ -1,10 +1,11 @@
 import React from "react"
 
 export default function ArticleNav(props) {
+  console.log("ArticleNav props: ", props)
   return (
     <nav className="navbar" role="navigation" aria-label="main navigation">
       <div className="navbar-brand">
-        <a className="navbar-item" href={props.metadata.link}>
+        <a className="navbar-item" href={props.metadata.siteUrl}>
           {props.metadata.shortName}
         </a>
 

--- a/src/components/ArticleNav.js
+++ b/src/components/ArticleNav.js
@@ -5,7 +5,7 @@ export default function ArticleNav(props) {
   return (
     <nav className="navbar" role="navigation" aria-label="main navigation">
       <div className="navbar-brand">
-        <a className="navbar-item" href={props.metadata.siteUrl}>
+        <a className="navbar-item" href="/">
           {props.metadata.shortName}
         </a>
 
@@ -19,11 +19,11 @@ export default function ArticleNav(props) {
       <div className="navbar-menu">
         <div className="navbar-start">
           <a className="navbar-item" href="/">
-            Articles
+            {props.metadata.nav.articles}
           </a>
 
           <a className="navbar-item" href="/topics">
-            Topics
+            {props.metadata.nav.topics}
           </a>
         </div>
 
@@ -31,7 +31,7 @@ export default function ArticleNav(props) {
           <div className="navbar-item">
             <div className="buttons">
                 <a className="button logout" href="/tinycms">
-                  tinycms
+                  {props.metadata.nav.cms}
                 </a>
             </div>
           </div>

--- a/src/components/SearchPanel.js
+++ b/src/components/SearchPanel.js
@@ -1,10 +1,10 @@
 import React from "react"
 
-export default function SearchPanel() {
+export default function SearchPanel(props) {
   return (
     <nav className="panel">
       <p className="panel-heading">
-        Search
+        {props.metadata.labels.search}
       </p>
       <div className="panel-block">
         <p className="control has-icons-left">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,7 +24,7 @@ export default function HomePage({ data }) {
 
   return(
     <div>
-      <ArticleNav name={data.site.siteMetadata.shortName} link={data.site.siteMetadata.siteUrl} />
+      <ArticleNav metadata={data.site.siteMetadata} />
       <Layout>
         <section className="hero is-primary is-bold">
           <div className="hero-body">
@@ -69,7 +69,7 @@ export default function HomePage({ data }) {
         <div>
         </div>
       </Layout>
-      <ArticleFooter />
+      <ArticleFooter metadata={data.site.siteMetadata} />
     </div>
   )
 }
@@ -82,6 +82,9 @@ export const query = graphql`
         shortName
         description
         siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
       }
     }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,7 @@ export default function HomePage({ data }) {
             <div className="column is-four-fifths">
               <aside className="menu">
                 <p className="menu-label">
-                  Latest News
+                  {data.site.siteMetadata.labels.latest_news}
                 </p>
                 <ul className="menu-list">
                   {data.allGoogleDocs.nodes.map(({ document }, index) => (
@@ -57,11 +57,11 @@ export default function HomePage({ data }) {
             <div className="column">
               <nav className="panel">
                 <p className="panel-heading">
-                  Topics
+                  {data.site.siteMetadata.labels.topics}
                 </p>
                 {tagLinks}
               </nav>
-              <SearchPanel />
+              <SearchPanel metadata={data.site.siteMetadata} />
             </div>
           </div>
         </section>
@@ -85,6 +85,11 @@ export const query = graphql`
         footerTitle
         footerBylineName
         footerBylineLink
+        labels {
+          latestNews
+          search
+          topics
+        }
         nav {
           articles
           topics

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -85,6 +85,11 @@ export const query = graphql`
         footerTitle
         footerBylineName
         footerBylineLink
+        nav {
+          articles
+          topics
+          cms
+        }
       }
     }
 

--- a/src/pages/topics.js
+++ b/src/pages/topics.js
@@ -23,7 +23,7 @@ export default function HomePage({ data }) {
 
   return(
     <div>
-      <ArticleNav />
+      <ArticleNav metadata={data.site.siteMetadata} />
       <Layout>
         <section className="section">
           <h3 className="title is-size-4 is-bold-light">Topics</h3>
@@ -34,13 +34,29 @@ export default function HomePage({ data }) {
           </aside>
         </section>
       </Layout>
-      <ArticleFooter />
+      <ArticleFooter metadata={data.site.siteMetadata} />
     </div>
   )
 }
 
 export const query = graphql`
   query {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        nav {
+          articles
+          topics
+          cms
+        }
+      }
+    }
     allGoogleDocs {
       edges {
         node {

--- a/src/pages/topics.js
+++ b/src/pages/topics.js
@@ -50,6 +50,11 @@ export const query = graphql`
         footerTitle
         footerBylineName
         footerBylineLink
+        labels {
+          latestNews
+          search
+          topics
+        }
         nav {
           articles
           topics

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -8,15 +8,15 @@ import "../pages/styles.scss"
 
 
 export default function Post({ data }) {
-  console.log(data);
   let doc = data.googleDocs.document;
   let articleHtml = data.googleDocs.childMarkdownRemark.html;
   //2020-05-03T22:22:14.981Z
   let parsedDate = parseISO(doc.createdTime)
 
+  console.log(data.site.siteMetadata);
   return (
     <div>
-      <ArticleNav />
+      <ArticleNav metadata={data.site.siteMetadata} />
 
       <Layout>
         <section className="hero is-bold">
@@ -52,13 +52,24 @@ export default function Post({ data }) {
         </section>
 
       </Layout>
-      <ArticleFooter />
+      <ArticleFooter metadata={data.site.siteMetadata} />
     </div>
   )
 }
 
 export const pageQuery = graphql`
   query($path: String!) {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+      }
+    }
     googleDocs(document: {path: {eq: $path}}) {
         document {
           author

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -68,6 +68,11 @@ export const pageQuery = graphql`
         footerTitle
         footerBylineName
         footerBylineLink
+        labels {
+          latestNews
+          search
+          topics
+        }
         nav {
           articles
           topics

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -68,6 +68,11 @@ export const pageQuery = graphql`
         footerTitle
         footerBylineName
         footerBylineLink
+        nav {
+          articles
+          topics
+          cms
+        }
       }
     }
     googleDocs(document: {path: {eq: $path}}) {

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -21,7 +21,7 @@ class Tag extends React.Component {
 
     return (
       <div>
-        <ArticleNav />
+        <ArticleNav metadata={data.site.siteMetadata} />
 
         <Layout>
           <section className="section">
@@ -30,7 +30,7 @@ class Tag extends React.Component {
           </section>
         </Layout>
 
-        <ArticleFooter />
+        <ArticleFooter metadata={data.site.siteMetadata} />
         </div>
     )
   }
@@ -40,6 +40,22 @@ export default Tag;
 
 export const tagPageQuery = graphql`
   query TagPage($tag: String) {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        nav {
+          articles
+          topics
+          cms
+        }
+      }
+    }
     allGoogleDocs(filter: {document: {tags: {in: [$tag]}}}) {
       edges {
         node {


### PR DESCRIPTION
This PR addresses Issue #4, moving all text from javascript and jsx templates into graphql. It does this by setting it up in gatsby-config.js.

I can already think of optimisations like:

* internationalisation/i18n
* making the graphql query [a fragment to avoid repetition](https://www.gatsbyjs.org/docs/using-graphql-fragments/)

but I figure it's smarter to do those things in the future as needed once use cases are better understood. This is a start.