### PR TITLE
Added google analytics plugin for integration with GA

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -66,5 +66,35 @@ module.exports = {
       `gatsby-plugin-sharp`,
       `gatsby-plugin-sass`,
 
+      {
+        resolve: `gatsby-plugin-google-analytics`,
+        options: {
+          // The property ID; the tracking code won't be generated without it
+          trackingId: "UA-166777432-1",
+          // Defines where to place the tracking script - `true` in the head and `false` in the body
+          head: true,
+          // Setting this parameter is optional
+          anonymize: true,
+          // Setting this parameter is also optional
+          respectDNT: true,
+          // Avoids sending pageview hits from custom paths
+          exclude: ["/preview/**", "/do-not-track/me/too/"],
+          // Delays sending pageview hits on route update (in milliseconds)
+          pageTransitionDelay: 0,
+          // Enables Google Optimize using your container Id
+          // optimizeId: "YOUR_GOOGLE_OPTIMIZE_TRACKING_ID",
+          // Enables Google Optimize Experiment ID
+          // experimentId: "YOUR_GOOGLE_EXPERIMENT_ID",
+          // Set Variation ID. 0 for original 1,2,3....
+          // variationId: "YOUR_GOOGLE_OPTIMIZE_VARIATION_ID",
+          // Defers execution of google analytics script after page load
+          defer: false,
+          // Any additional optional fields
+          // sampleRate: 5,
+          // siteSpeedSampleRate: 10,
+          // cookieDomain: "example.com",
+        },
+      },
+
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9460,6 +9460,15 @@
         "micromatch": "^3.1.10"
       }
     },
+    "gatsby-plugin-google-analytics": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.1.tgz",
+      "integrity": "sha512-2dfaWVxAScwMMs00g5QJ4vHHOmj9i/3MWeC273zjpC8IW35IXw/ypcDg+O7Kh+Q/Xwok1pS+c+LREic8E08iYQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "minimatch": "3.0.4"
+      }
+    },
     "gatsby-plugin-netlify-cms": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "date-fns": "^2.12.0",
     "gapi-script": "^1.0.2",
     "gatsby": "^2.21.7",
+    "gatsby-plugin-google-analytics": "^2.3.1",
     "gatsby-plugin-netlify-cms": "^4.3.0",
     "gatsby-plugin-sass": "^2.3.0",
     "gatsby-plugin-sharp": "^2.6.0",


### PR DESCRIPTION
This PR addresses issue #6 and sets up the demo / gatsby starter with GA integration. I setup a new GA account for the demo and plugged the tracking ID into `gatsby-config.js` where the [plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/) is configured.