### PR TITLE
Working implementation of twitter embeds with shortcode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,6 +2222,11 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
     },
+    "@types/domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA=="
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -2767,6 +2772,23 @@
         "indent-string": "^4.0.0"
       }
     },
+    "airbnb-prop-types": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
+      "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
+      "requires": {
+        "array.prototype.find": "^2.1.0",
+        "function.prototype.name": "^1.1.1",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.9.0"
+      }
+    },
     "ajv": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
@@ -3108,6 +3130,15 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "array.prototype.find": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
+      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.4"
+      }
     },
     "array.prototype.flat": {
       "version": "1.2.3",
@@ -6943,6 +6974,44 @@
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
       "integrity": "sha512-hQBkDf2iO4Nv0CNHpCuSBeaSrveU6nThVxFGTrq/eDlV716UQk09zChaJae4mZRsos1x4YLY2TaH3LHUae3ZmQ=="
     },
+    "enzyme-adapter-react-16": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.2.tgz",
+      "integrity": "sha512-SkvDrb8xU3lSxID8Qic9rB8pvevDbLybxPK6D/vW7PrT0s2Cl/zJYuXvsd1EBTz0q4o3iqG3FJhpYz3nUNpM2Q==",
+      "requires": {
+        "enzyme-adapter-utils": "^1.13.0",
+        "enzyme-shallow-equal": "^1.0.1",
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.12.0",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.7.0"
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.13.0.tgz",
+      "integrity": "sha512-YuEtfQp76Lj5TG1NvtP2eGJnFKogk/zT70fyYHXK2j3v6CtuHqc8YmgH/vaiBfL8K1SgVVbQXtTcgQZFwzTVyQ==",
+      "requires": {
+        "airbnb-prop-types": "^2.15.0",
+        "function.prototype.name": "^1.1.2",
+        "object.assign": "^4.1.0",
+        "object.fromentries": "^2.0.2",
+        "prop-types": "^15.7.2",
+        "semver": "^5.7.1"
+      }
+    },
+    "enzyme-shallow-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz",
+      "integrity": "sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==",
+      "requires": {
+        "has": "^1.0.3",
+        "object-is": "^1.0.2"
+      }
+    },
     "eol": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
@@ -9040,10 +9109,25 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.prototype.name": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
+      "integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "functions-have-names": "^1.2.0"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "functions-have-names": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
+      "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA=="
     },
     "fuzzy": {
       "version": "0.1.3",
@@ -11739,6 +11823,16 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
+    "html-dom-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-0.2.3.tgz",
+      "integrity": "sha512-GdzE63/U0IQEvcpAz0cUdYx2zQx0Ai+HWvE9TXEgwP27+SymUzKa7iB4DhjYpf2IdNLfTTOBuMS5nxeWOosSMQ==",
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "domhandler": "2.4.2",
+        "htmlparser2": "3.10.1"
+      }
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -11773,10 +11867,68 @@
         }
       }
     },
+    "html-react-parser": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-0.10.3.tgz",
+      "integrity": "sha512-9Q/r6lyp5R3dvtiNBt1PJ/9XIKvsP6GQ7ppJA/82e9qFZOJuMJFMHj+HYjRDfFrFvAhRxYsjA4yNmFEDffZW1g==",
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "html-dom-parser": "0.2.3",
+        "react-property": "1.0.1",
+        "style-to-object": "0.3.0"
+      }
+    },
     "html-tag-names": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.5.tgz",
       "integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A=="
+    },
+    "html-to-react": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.2.tgz",
+      "integrity": "sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==",
+      "requires": {
+        "domhandler": "^3.0",
+        "htmlparser2": "^4.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "domhandler": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
+          "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
+          "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
+          "requires": {
+            "dom-serializer": "^0.2.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        }
+      }
     },
     "html-void-elements": {
       "version": "1.0.5",
@@ -13931,6 +14083,11 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -17392,6 +17549,16 @@
         "react-is": "^16.8.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
+      }
+    },
     "property-information": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
@@ -17541,6 +17708,11 @@
       "requires": {
         "performance-now": "^2.1.0"
       }
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -17992,6 +18164,16 @@
         }
       }
     },
+    "react-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-1.0.1.tgz",
+      "integrity": "sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ=="
+    },
+    "react-proptype-conditional-require": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz",
+      "integrity": "sha1-acLVdB5t9eCPIw82u8KUTuEiJVU="
+    },
     "react-reconciler": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
@@ -18132,12 +18314,42 @@
         "react-style-proptype": "^3.2.2"
       }
     },
+    "react-string-replace": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-0.4.4.tgz",
+      "integrity": "sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
     "react-style-proptype": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz",
       "integrity": "sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==",
       "requires": {
         "prop-types": "^15.5.4"
+      }
+    },
+    "react-test-renderer": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
+      "integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-textarea-autosize": {
@@ -18182,6 +18394,17 @@
             "loose-envify": "^1.0.0"
           }
         }
+      }
+    },
+    "react-twitter-embed": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-twitter-embed/-/react-twitter-embed-3.0.3.tgz",
+      "integrity": "sha512-kF1Srlb1TqnZUqKA0FC4I/E+m+RUBCMZeU20hDRzmYLAjR1EA/6tr/PMZ22s7rd6wjQpIBLXNZjt0rfUpY8Chw==",
+      "requires": {
+        "enzyme-adapter-react-16": "^1.11.0",
+        "exenv": "^1.2.2",
+        "react-proptype-conditional-require": "^1.0.4",
+        "scriptjs": "^2.5.9"
       }
     },
     "react-virtualized-auto-sizer": {
@@ -18411,6 +18634,11 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
     },
     "regenerate": {
       "version": "1.4.0",
@@ -19552,6 +19780,11 @@
         "ajv": "^6.12.0",
         "ajv-keywords": "^3.4.1"
       }
+    },
+    "scriptjs": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
     },
     "scroll-behavior": {
       "version": "0.9.12",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "bulma": "^0.8.2",
     "date-fns": "^2.12.0",
     "gapi-script": "^1.0.2",
-    "gatsby-plugin-amp": "^0.2.2",
-    "gatsby-plugin-mailchimp": "^5.1.2",
-    "gatsby-plugin-google-analytics": "^2.3.1",
     "gatsby": "^2.21.31",
+    "gatsby-plugin-amp": "^0.2.2",
+    "gatsby-plugin-google-analytics": "^2.3.1",
+    "gatsby-plugin-mailchimp": "^5.1.2",
     "gatsby-plugin-netlify-cms": "^4.3.0",
     "gatsby-plugin-sass": "^2.3.0",
     "gatsby-plugin-sharp": "^2.6.0",
@@ -33,11 +33,15 @@
     "gatsby-source-google-docs": "^2.0.0-beta.6",
     "gatsby-transformer-remark": "^2.8.4",
     "gootenberg": "^1.4.2",
+    "html-react-parser": "^0.10.3",
+    "html-to-react": "^1.4.2",
     "netlify-cms-app": "^2.12.11",
     "node-sass": "^4.14.0",
     "query-string": "^6.12.1",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-string-replace": "^0.4.4",
+    "react-twitter-embed": "^3.0.3"
   },
   "devDependencies": {
     "prettier": "2.0.5"

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,46 +1,69 @@
-import React from "react"
-import { Link, graphql } from "gatsby"
+import React from 'react';
+import { graphql, Link } from "gatsby"
+
+import { parseISO, formatRelative } from 'date-fns'
+import { TwitterTweetEmbed } from 'react-twitter-embed';
+import { Parser, ProcessNodeDefinitions } from "html-to-react";
+
 import ArticleFooter from "../components/ArticleFooter"
 import ArticleNav from "../components/ArticleNav"
 import Layout from "../components/Layout"
-import { parseISO, formatRelative } from 'date-fns'
 import "../pages/styles.scss"
 
+let tweetRegex = /\[tweet id=(.*?)\]/i;
+const htmlParser = new Parser(React);
+const processNodeDefinitions = new ProcessNodeDefinitions(React);
+function isValidNode(){
+    return true;
+}
+const processingInstructions = [
+  // Create instruction for custom elements
+  {
+      shouldProcessNode: (node) => {
+          // Process the node if it matches a custom element
+          let foundMatch = (node.data && tweetRegex.test(node.data));
+          if (foundMatch) {
+            console.log(node.data);
+          }
+          return foundMatch;
+      },
+      processNode: (node) => {
+        let result = tweetRegex.exec(node.data);
+        let tweetId = result[1];
+        return <TwitterTweetEmbed tweetId={tweetId} />;
+      }
+  },
+  // Default processing
+  {
+      shouldProcessNode: () => true,
+      processNode: processNodeDefinitions.processDefaultNode
+  }
+];
 
-export default function Post({ data }) {
-  let doc = data.googleDocs.document;
-  let articleHtml = data.googleDocs.childMarkdownRemark.html;
-  //2020-05-03T22:22:14.981Z
-  let parsedDate = parseISO(doc.createdTime)
-
-  console.log(data.site.siteMetadata);
-  return (
-    <div>
-      <ArticleNav metadata={data.site.siteMetadata} />
-
-      <Layout>
-        <section className="hero is-bold">
-          <div className="hero-body">
-            <div className="container">
-              <h1 className="title">
-                {doc.name}
-              </h1>
-              <h2 className="subtitle">
-                By {doc.author} | Published {formatRelative(parsedDate, new Date())} 
-              </h2>
+export default class Posttest extends React.Component {
+  render () {
+    let data = this.props.data;
+    let doc = data.googleDocs.document;
+    let parsedDate = parseISO(doc.createdTime)
+    let articleHtml = data.googleDocs.childMarkdownRemark.html;
+    let updatedHtml = htmlParser.parseWithInstructions(articleHtml, isValidNode, processingInstructions);
+    return (
+      <div>
+        <ArticleNav metadata={data.site.siteMetadata} />
+        <Layout>
+          <section className="hero is-bold">
+            <div className="hero-body">
+              <div className="container">
+                <h1 className="title">
+                  {doc.name}
+                </h1>
+                <h2 className="subtitle">
+                  By {doc.author} | Published {formatRelative(parsedDate, new Date())} 
+                </h2>
+              </div>
             </div>
-          </div>
-        </section>
-
-        <section className="section">
-          <div className="content">
-
-              <div
-                dangerouslySetInnerHTML={{__html: articleHtml}}
-              />
-          </div>
-        </section>
-
+          </section>
+          {updatedHtml}
         <section className="section">
           <div className="container">
             <div className="tags">
@@ -54,7 +77,8 @@ export default function Post({ data }) {
       </Layout>
       <ArticleFooter metadata={data.site.siteMetadata} />
     </div>
-  )
+    )
+  }
 }
 
 export const pageQuery = graphql`


### PR DESCRIPTION
This takes care of a piece of Issue #14 by implementing a short code for embedding tweets. 

It was surprisingly tricky for me to get this working because of how the google html was being rendered onto the page (with `dangerouslySetInnerHTML`). I have totally replaced how the html is now rendered, which allows us to iterate node by node... and we now have greater control of the output, so that's a win 👍 Also, we no longer use `dangerouslySetInnerHTML` which is also probably for the best.

Usage, in Google Doc:

`[tweet id=1262182320209092609]`

Output, in published html:

<img width="644" alt="Screen Shot 2020-05-19 at 11 23 12 am" src="https://user-images.githubusercontent.com/3397/82274311-2a906500-99c3-11ea-8f7a-7f4bd8af6958.png">

To-do:

* all the other embeds