### PR TITLE
Default page rendering to AMP

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -122,7 +122,7 @@ module.exports = {
           canonicalBaseUrl: 'http://tinynewsco.org/',
           components: ['amp-form'],
           excludedPaths: ['/404*', '/'],
-          pathIdentifier: '/amp/',
+          pathIdentifier: '/',
           relAmpHtmlPattern: '{{canonicalBaseUrl}}{{pathname}}{{pathIdentifier}}',
           useAmpClientIdApi: true,
         },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,14 +25,14 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             path: document.path,
             component: path.resolve(`./src/templates/post.js`),
         })
-        console.log("creating AMP page for google doc at ", `${document.path}/amp`)
-        actions.createPage({
-          path: `${document.path}/amp`,
-          component: path.resolve('./src/templates/post.amp.js'),
-          context: {
-            slug: document.path,
-          }
-        })
+        // console.log("creating AMP page for google doc at ", `${document.path}/amp`)
+        // actions.createPage({
+        //   path: `${document.path}/amp`,
+        //   component: path.resolve('./src/templates/post.amp.js'),
+        //   context: {
+        //     slug: document.path,
+        //   }
+        // })
       })
 
       tags = _.uniq(tags)

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -33,8 +33,8 @@ const processingInstructions = [
         let result = tweetRegex.exec(node.data);
         if (result && result[1]) {
           let tweetId = result[1];
-          return <div></div>
-          // return <Embed width={560} url={`https://twitter.com/${tweetId}`} />
+          // return <div></div>
+          return <Embed width={560} url={`https://twitter.com/${tweetId}`} />
         } else {
           // matched an entire url
           return <Embed width={560} url={node.data} />


### PR DESCRIPTION
This PR defaults page rendering to AMP instead of publishing a separate version of each at $url + `/amp/`

You'll see this now in the console on AMP enhanced pages:

Powered by AMP ⚡ HTML – Version 2005151844001 http://localhost:8000/articles/our-analysis-of-the-data-reveals/
