### PR TITLE
Set default editable tags for editor

### DIFF
--- a/src/components/GoogleLogin.js
+++ b/src/components/GoogleLogin.js
@@ -95,6 +95,27 @@ class GoogleLogin extends Component {
       }
     }
 
+    getDocData = (description) => {
+      let docData;
+      if ( (!description || /^\s*$/.test(description)) ) {
+        console.log("description is blank");
+        docData = {
+          "author": "Ace Reporter",
+          "tags": ["news"],
+          "og_type":"website",
+          "og_locale":"en_US",
+          "og_url":"https://tinynewsco.org/",
+          "og_site_name":"tiny news co",
+          "tw_handle":"@tinynewsco",
+          "tw_site":"@newscatalyst",
+          "tw_cardType":"summary_large_image"
+        }
+      } else {
+        docData = JSON.parse(description);
+      }
+      return docData;
+    }
+
     // UPDATE state with document metadata
     updateDocData = (docData) => {
       this.setState({
@@ -154,9 +175,10 @@ class GoogleLogin extends Component {
           }).then(response => {
             // PARSE description JSON for document metadata
             let docName = response.result.name;
-            let doc = JSON.parse(response.result.description);
+
+            let docData = this.getDocData(response.result.description);
             // STORE doc metadata in react state
-            this.updateDocData(doc);
+            this.updateDocData(docData);
             // STORE doc name at top-level react state
             // I'm doing this to avoid potentially storing it unnecessarily in the doc description
             this.updateDocName(docName);

--- a/src/components/GoogleLogin.js
+++ b/src/components/GoogleLogin.js
@@ -103,11 +103,15 @@ class GoogleLogin extends Component {
           "author": "Ace Reporter",
           "tags": ["news"],
           "og_type":"website",
+          "og_title":"",
+          "og_description":"",
           "og_locale":"en_US",
-          "og_url":"https://tinynewsco.org/",
-          "og_site_name":"tiny news co",
-          "tw_handle":"@tinynewsco",
-          "tw_site":"@newscatalyst",
+          "og_image_url": "",
+          "og_image_alt": "",
+          "og_url":"",
+          "og_site_name":"",
+          "tw_handle":"@",
+          "tw_site":"@",
           "tw_cardType":"summary_large_image"
         }
       } else {


### PR DESCRIPTION
This PR is part of the work required for making SEO/social tags editable in issue #22. It sets a default group of tags (opengraph type, url, etc) for the tinycms edit form.

Next:

* pull these values when publishing articles
* configure this set of fields in gatsby-config?
 * will they really change per-tinynewsco?