### PR TITLE
Feature/use custom seo tags

### DIFF
--- a/src/components/GoogleLogin.js
+++ b/src/components/GoogleLogin.js
@@ -95,6 +95,27 @@ class GoogleLogin extends Component {
       }
     }
 
+    getDocData = (description) => {
+      let docData;
+      if ( (!description || /^\s*$/.test(description)) ) {
+        console.log("description is blank");
+        docData = {
+          "author": "Ace Reporter",
+          "tags": ["news"],
+          "og_type":"website",
+          "og_locale":"en_US",
+          "og_url":"https://tinynewsco.org/",
+          "og_site_name":"tiny news co",
+          "tw_handle":"@tinynewsco",
+          "tw_site":"@newscatalyst",
+          "tw_cardType":"summary_large_image"
+        }
+      } else {
+        docData = JSON.parse(description);
+      }
+      return docData;
+    }
+
     // UPDATE state with document metadata
     updateDocData = (docData) => {
       this.setState({
@@ -154,9 +175,10 @@ class GoogleLogin extends Component {
           }).then(response => {
             // PARSE description JSON for document metadata
             let docName = response.result.name;
-            let doc = JSON.parse(response.result.description);
+
+            let docData = this.getDocData(response.result.description);
             // STORE doc metadata in react state
-            this.updateDocData(doc);
+            this.updateDocData(docData);
             // STORE doc name at top-level react state
             // I'm doing this to avoid potentially storing it unnecessarily in the doc description
             this.updateDocName(docName);

--- a/src/components/GoogleLogin.js
+++ b/src/components/GoogleLogin.js
@@ -103,11 +103,15 @@ class GoogleLogin extends Component {
           "author": "Ace Reporter",
           "tags": ["news"],
           "og_type":"website",
+          "og_title":"",
+          "og_description":"",
           "og_locale":"en_US",
-          "og_url":"https://tinynewsco.org/",
-          "og_site_name":"tiny news co",
-          "tw_handle":"@tinynewsco",
-          "tw_site":"@newscatalyst",
+          "og_image_url": "",
+          "og_image_alt": "",
+          "og_url":"",
+          "og_site_name":"",
+          "tw_handle":"@",
+          "tw_site":"@",
           "tw_cardType":"summary_large_image"
         }
       } else {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -8,8 +8,8 @@ export default function Layout(props) {
       title={props.title}
       description={props.description}
       openGraph={{
-        title: props.title,
-        description: props.description,
+        title: props.og_title,
+        description: props.og_description,
         images: [
           {
             url: props.og_image_url,
@@ -19,6 +19,12 @@ export default function Layout(props) {
           },
         ],
       }}
+      twitter={{
+        handle: props.tw_handle,
+        site: props.tw_site,
+        cardType: props.tw_cardType,
+      }}
+
     />
 
     <div className="container">

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -19,7 +19,6 @@ const processingInstructions = [
   {
     replaceChildren: true,
     shouldProcessNode: (node) => {
-      console.log("replace children shouldProcessNode: ", node);
       return (node.children !== undefined && node.children.length == 3 && (/\[embed src=\s/).test(node.children[0].data));
     },
     processNode: (node, children, index) => {
@@ -69,7 +68,7 @@ export default class Posttest extends React.Component {
     return (
       <div>
         <ArticleNav metadata={data.site.siteMetadata} />
-        <Layout title={doc.name} description={data.googleDocs.childMarkdownRemark.excerpt}>
+        <Layout title={doc.name} description={data.googleDocs.childMarkdownRemark.excerpt} {...doc}>
           <section className="hero is-bold">
             <div className="hero-body">
               <div className="container">
@@ -132,6 +131,16 @@ export const pageQuery = graphql`
           createdTime
           name
           tags
+          og_locale
+          og_title
+          og_description
+          og_image_url
+          og_image_alt
+          og_site_name
+          og_url
+          tw_handle
+          tw_site
+          tw_cardType
         }
         childMarkdownRemark {
           excerpt


### PR DESCRIPTION
This PR continues the work for #22 by adding SEO fields to the article graphql query and passing those values to the `<Layout>` component for filling in SEO and social meta tags.