### PR TITLE
Feature/fix build errors graphql schema

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,29 @@
 const _ = require('lodash')
 const path = require(`path`)
 
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type Document implements Node {
+      name: String!
+      author: String
+      createdTime: Date
+      tags: [String]
+      og_locale: String
+      og_title: String
+      og_description: String
+      og_image_url: String
+      og_image_alt: String
+      og_site_name: String
+      og_url: String
+      tw_handle: String
+      tw_site: String
+      tw_cardType: String
+    }
+  `
+  createTypes(typeDefs)
+}
+
 exports.createPages = async ({ actions, graphql, reporter }) => {
   graphql(
     `
@@ -26,7 +49,11 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         })
       })
 
+      tags = tags.filter(function (el) {
+        return el != null;
+      });
       tags = _.uniq(tags)
+      console.log(tags);
       console.log("Making", tags.length, "tag pages...")
       tags.forEach(tag => {
         const tagPath = `/topics/${_.kebabCase(tag)}/`

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -65,6 +65,12 @@ export default class Posttest extends React.Component {
     let data = this.props.data;
     let doc = data.googleDocs.document;
     let parsedDate = parseISO(doc.createdTime)
+    let tagLinks;
+    if (doc.tags) {
+      tagLinks = doc.tags.map((tag, index) => (
+        <Link to={`/topics/${tag}`} key={`${tag}-${index}`} className="is-link tag">{tag}</Link>
+      ))
+    } 
     return (
       <div>
         <ArticleNav metadata={data.site.siteMetadata} />
@@ -89,9 +95,7 @@ export default class Posttest extends React.Component {
           <section className="section">
             <div className="container">
               <div className="tags">
-                {doc.tags.map((tag, index) => (
-                  <Link to={`/topics/${tag}`} key={`${tag}-${index}`} className="is-link tag">{tag}</Link>
-                ))}
+                {tagLinks}
               </div>
             </div>
           </section>


### PR DESCRIPTION
This PR fixes two problems with the build:

1. Defines a [graphql schema](https://www.gatsbyjs.org/docs/schema-customization/#nested-types)
2. Ensures tags exist on the article before calling `map` on them

The schema means slight performance gains (gatsby has to do less type inference) and avoids errors with expected fields being missing.

The `tags` fix means `.map` won't be called on a `null` value.