### PR TITLE
Removed unused filesystem plugin for markdown

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,13 +33,6 @@ module.exports = {
   plugins: 
     [
       {
-        resolve: `gatsby-source-filesystem`,
-        options: {
-          name: `markdown-pages`,
-          path: `${__dirname}/src/markdown-pages`,
-        },
-      },
-      {
         resolve: `gatsby-transformer-remark`,
         options: {
           plugins: [
@@ -59,24 +52,7 @@ module.exports = {
       {
         resolve: "gatsby-source-google-docs",
         options: {
-            //---
-            // All the following options are OPTIONAL
-            //---
-            //
-            // To fetch only documents to specific folders
-            // folders Ids can be found in Google Drive URLs
-            // https://drive.google.com/drive/folders/FOLDER_ID
             folders: ["1lcfhd58_0D6-uP0Dwb0a_-Yri2L0h-6K"],
-            // You could need to fetch additional documents fields to your nodes
-            // All available options: https://developers.google.com/drive/api/v3/reference/files#resource
-            // fields: ["ownedByMe", "shared"],
-            // To rename fields
-            // Be carrefull, some documentation instructions could be different
-            // fieldsMapper: {createdTime: "date", name: "title"},
-            // To add default fields values
-            // fieldsDefault: {draft: false},
-            // For a better stack trace and more information
-            // Usefull when you open a issue to report a bug
             debug: true,
         }
       },

--- a/src/markdown-pages/post-1.md
+++ b/src/markdown-pages/post-1.md
@@ -1,5 +1,0 @@
----
-path: "/blog/my-first-post"
-date: "2019-05-04"
-title: "My first blog post"
----


### PR DESCRIPTION
Small PR - I noticed this plugin supporting markdown pages was still in the app (it comes with the original gatsby starter) but unused. This removes both the plugin and the example markdown source page from the app. 