### PR TITLE
Web Vitals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22118,6 +22118,11 @@
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
+    "web-vitals": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.2.tgz",
+      "integrity": "sha512-6xR6kxa70XXnSHV4sZMDXKPvcrUfl2xaNUN1ENedcDbvcinzlWgaDD5Hn5mAnfHfKZVlSHe2/XCXKweuRnfWqw=="
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-helmet-async": "^1.0.6",
     "react-player": "^2.1.1",
     "react-string-replace": "^0.4.4",
-    "react-twitter-embed": "^3.0.3"
+    "react-twitter-embed": "^3.0.3",
+    "web-vitals": "^0.2.2"
   },
   "devDependencies": {
     "prettier": "2.0.5"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,6 @@ import React, { useEffect } from "react"
 import _ from 'lodash'
 import { Link, graphql } from "gatsby"
 import {getCLS, getFID, getLCP} from 'web-vitals';
-
 import ArticleFooter from "../components/ArticleFooter"
 import ArticleLink from "../components/ArticleLink"
 import ArticleNav from "../components/ArticleNav"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,14 +1,24 @@
-import React from "react"
+import React, { useEffect } from "react"
 import _ from 'lodash'
 import { Link, graphql } from "gatsby"
+import {getCLS, getFID, getLCP} from 'web-vitals';
+
 import ArticleFooter from "../components/ArticleFooter"
 import ArticleLink from "../components/ArticleLink"
 import ArticleNav from "../components/ArticleNav"
 import SearchPanel from "../components/SearchPanel"
 import Layout from "../components/Layout"
+import sendToGoogleAnalytics from "../utils/vitals"
+
 import "./styles.scss"
 
 export default function HomePage({ data }) {
+  useEffect(() => {
+    getCLS(sendToGoogleAnalytics);
+    getFID(sendToGoogleAnalytics);
+    getLCP(sendToGoogleAnalytics);
+  }, []);
+
   let tags = [];
   data.allGoogleDocs.nodes.forEach(({document}, index) => {
     tags = tags.concat(document.tags);

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,11 +1,13 @@
-import React from 'react';
+import React from "react"
 import { graphql, Link } from "gatsby"
 import { parseISO, formatRelative } from 'date-fns'
 import Embed from 'react-embed';
+import {getCLS, getFID, getLCP} from 'web-vitals';
 import { Parser, ProcessNodeDefinitions } from "html-to-react";
 import ArticleFooter from "../components/ArticleFooter"
 import ArticleNav from "../components/ArticleNav"
 import Layout from "../components/Layout"
+import sendToGoogleAnalytics from "../utils/vitals"
 import "../pages/styles.scss"
 
 let embedRegex = /\[embed src=\s*(.*?)\]/i;
@@ -69,6 +71,9 @@ export default class Posttest extends React.Component {
     this.setState({
       articleHtml: updatedHtml,
     })
+    getCLS(sendToGoogleAnalytics);
+    getFID(sendToGoogleAnalytics);
+    getLCP(sendToGoogleAnalytics);
   }
 
   render () {

--- a/src/utils/vitals.js
+++ b/src/utils/vitals.js
@@ -1,20 +1,11 @@
+import { trackCustomEvent } from 'gatsby-plugin-google-analytics'
 
 export default function sendToGoogleAnalytics({name, delta, id}) {
-  // Assumes the global `ga()` function exists, see:
-  // https://developers.google.com/analytics/devguides/collection/analyticsjs
-  window.ga('send', 'event', {
-    eventCategory: 'Web Vitals',
-    eventAction: name,
-    // Google Analytics metrics must be integers, so the value is rounded.
-    // For CLS the value is first multiplied by 1000 for greater precision
-    // (note: increase the multiplier for greater precision if needed).
-    eventValue: Math.round(name === 'CLS' ? delta * 1000 : delta),
-    // The `id` value will be unique to the current page load. When sending
-    // multiple values from the same page (e.g. for CLS), Google Analytics can
-    // compute a total by grouping on this ID (note: requires `eventLabel` to
-    // be a dimension in your report).
-    eventLabel: id,
-    // Use a non-interaction event to avoid affecting bounce rate.
+  trackCustomEvent({
+    category: "Web Vitals",
+    action: name,
+    value: Math.round(name === 'CLS' ? delta * 1000 : delta),
+    label: id,
     nonInteraction: true,
   });
 }

--- a/src/utils/vitals.js
+++ b/src/utils/vitals.js
@@ -1,0 +1,20 @@
+
+export default function sendToGoogleAnalytics({name, delta, id}) {
+  // Assumes the global `ga()` function exists, see:
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs
+  window.ga('send', 'event', {
+    eventCategory: 'Web Vitals',
+    eventAction: name,
+    // Google Analytics metrics must be integers, so the value is rounded.
+    // For CLS the value is first multiplied by 1000 for greater precision
+    // (note: increase the multiplier for greater precision if needed).
+    eventValue: Math.round(name === 'CLS' ? delta * 1000 : delta),
+    // The `id` value will be unique to the current page load. When sending
+    // multiple values from the same page (e.g. for CLS), Google Analytics can
+    // compute a total by grouping on this ID (note: requires `eventLabel` to
+    // be a dimension in your report).
+    eventLabel: id,
+    // Use a non-interaction event to avoid affecting bounce rate.
+    nonInteraction: true,
+  });
+}


### PR DESCRIPTION
This PR adds google's [new site health metrics](https://web.dev/vitals/) library to the tinynewsco site:

* integrating with google analytics (previously setup)
* function for sending data in `/static/vitals.js`
* added metric/tracking call to homepage and article pages

Something to note: the google analytics library we're using doesn't track when running `gatsby develop` so you need to `gatsby build && gatsby serve` to see the api calls happening. I did test this branch in both gatsby modes in chrome and firefox, though, due to recent experiences ;) 

Related: issue #42