### PR TITLE
Tag page fixes

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -52,7 +52,7 @@ export default function HomePage({ data }) {
             </div>
           </div>
         </section>
-        <div class="featured-article">
+        <div className="featured-article">
           {data.allGoogleDocs.nodes.slice(0, 1).map(({ document, childMarkdownRemark }, index) => (
             <FeaturedArticleLink key={document.path} document={document} excerpt={childMarkdownRemark.excerpt} /> 
           ))}

--- a/src/pages/topics.js
+++ b/src/pages/topics.js
@@ -11,9 +11,13 @@ export default function HomePage({ data }) {
   data.allGoogleDocs.edges.forEach(({node}, index) => {
     tags = tags.concat(node.document.tags);
   })
+  // remove any null tags
+  tags = tags.filter(function (el) {
+    return el != null;
+  });
   tags = _.uniq(tags).sort();
   const tagLinks = tags.map( (tag, index) => (
-    <li key={index}><Link to={`/topics/${tag}`}>{_.startCase(tag)}</Link></li>
+    <li key={index}><Link to={`/topics/${_.kebabCase(tag)}`}>{_.startCase(tag)}</Link></li>
   ));
 
 
@@ -58,7 +62,7 @@ export const query = graphql`
         }
       }
     }
-    allGoogleDocs {
+    allGoogleDocs(filter: {document: {breadcrumb: {nin: "Drafts"}}}) {
       edges {
         node {
           document {

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,4 +1,5 @@
 import React from "react"
+import _ from 'lodash'
 import { graphql, Link } from "gatsby"
 import { parseISO, formatRelative } from 'date-fns'
 import Embed from 'react-embed';
@@ -83,7 +84,7 @@ export default class Posttest extends React.Component {
     let tagLinks;
     if (doc.tags) {
       tagLinks = doc.tags.map((tag, index) => (
-        <Link to={`/topics/${tag}`} key={`${tag}-${index}`} className="is-link tag">{tag}</Link>
+        <Link to={`/topics/${_.kebabCase(tag)}`} key={`${tag}-${index}`} className="is-link tag">{tag}</Link>
       ))
     }
     return (


### PR DESCRIPTION
Related to issue #51, this fixes a few issues with tags:

* the /topics page query was not correct and included draft articles; now it doesn't
* the /topics page wasn't generating tag-specific urls correctly; it's now in line with how gatsby-node.js creates these pages using `kebabCase`
* the tag links under each article also now generate the urls correctly using `kebabCase`

Also a small fix for the homepage, there was a `class=` instead of a `className=`, fixed.
