### PR TITLE
Simplified embed functionality by matching a URL alone

### DIFF
--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -15,6 +15,73 @@ import "../pages/styles.scss"
 // Look for URLs in the article copy for embedding social media
 let urlRegex = /(https?:\/\/)?([\w\-])+\.{1}([a-zA-Z]{2,63})([\/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)/i; 
 
+const MATCH_URL_DAILY_MOTION = /^(?:(?:https?):)?(?:\/\/)?(?:www\.)?(?:(?:dailymotion\.com(?:\/embed)?\/video)|dai\.ly)\/([a-zA-Z0-9]+)(?:_[\w_-]+)?$/;
+const canEmbedDailyMotion = (url) => MATCH_URL_DAILY_MOTION.test(url);
+
+const MATCH_URL_FACEBOOK = /facebook\.com\/.+/;
+const canEmbedFacebook = (url) => MATCH_URL_FACEBOOK.test(url);
+
+const MATCH_URL_GOOGLE = /google\.com\/.+/;
+const canEmbedGoogle = (url) => MATCH_URL_GOOGLE.test(url);
+
+const MATCH_URL_INSTAGRAM = /instagram\.com\/.+/;
+const canEmbedInstagram = (url) => MATCH_URL_INSTAGRAM.test(url);
+
+const MATCH_URL_IMGUR = /imgur\.com\/.+/;
+const canEmbedImgur = (url) => MATCH_URL_IMGUR.test(url);
+
+const MATCH_URL_MIXCLOUD = /mixcloud\.com\/([^/]+\/[^/]+)/;
+const canEmbedMixcloud = (url) => MATCH_URL_MIXCLOUD.test(url);
+
+const MATCH_VIDEO_URL_TWITCH = /(?:www\.|go\.)?twitch\.tv\/videos\/(\d+)($|\?)/;
+const MATCH_CHANNEL_URL_TWITCH = /(?:www\.|go\.)?twitch\.tv\/([a-z0-9_]+)($|\?)/;
+const canEmbedTwitch = (url) => MATCH_VIDEO_URL_TWITCH.test(url) || MATCH_CHANNEL_URL_TWITCH.test(url);
+
+const MATCH_URL_TWITTER = /twitter\.com\/.+/;
+const canEmbedTwitter = (url) => MATCH_URL_TWITTER.test(url);
+
+const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})|youtube\.com\/playlist\?list=/
+const canEmbedYoutube = url => MATCH_URL_YOUTUBE.test(url);
+
+const MATCH_URL_VIMEO = /vimeo\.com\/.+/;
+const MATCH_FILE_URL_VIMEO = /vimeo\.com\/external\/.+\.mp4/;
+const canEmbedVimeo = (url) => {
+  if (MATCH_FILE_URL_VIMEO.test(url)) {
+    return false;
+  }
+  return MATCH_URL_VIMEO.test(url);
+};
+
+const MATCH_URL_SOUNDCLOUD = /(soundcloud\.com|snd\.sc)\/.+$/;
+const canEmbedSoundcloud = url => MATCH_URL_SOUNDCLOUD.test(url);
+
+const MATCH_URL_STREAMABLE = /streamable\.com\/([a-z0-9]+)$/;
+const canEmbedStreamable = (url) => MATCH_URL_STREAMABLE.test(url);
+
+function isValidUrl(url) {
+  let validUrl = urlRegex.test(url);
+  console.log(url, "is it valid? ", validUrl);
+  if (!validUrl) {
+    return false; // don't bother processing further
+  }
+  let supportedPlatform = ( 
+    canEmbedDailyMotion(url) || 
+    canEmbedFacebook(url) ||
+    canEmbedGoogle(url) || 
+    canEmbedImgur(url) || 
+    canEmbedInstagram(url) ||
+    canEmbedMixcloud(url) || 
+    canEmbedSoundcloud(url) || 
+    canEmbedStreamable(url) || 
+    canEmbedTwitch(url) ||
+    canEmbedTwitter(url) || 
+    canEmbedYoutube(url) || 
+    canEmbedVimeo(url) );
+
+  console.log(url, "is it supported? ", supportedPlatform);
+  return validUrl && supportedPlatform;
+}
+
 const htmlParser = new Parser(React);
 const processNodeDefinitions = new ProcessNodeDefinitions(React);
 function isValidNode(){
@@ -24,7 +91,7 @@ const processingInstructions = [
   // first, should this block become an embed? try matching against URL regex
   {
       shouldProcessNode: (node) => {
-        let foundMatch = (node.data && urlRegex.test(node.data));
+        let foundMatch = (node.data && isValidUrl(node.data));
         return foundMatch;
   },
   // processNode gets executed if shouldProcessNode returns true


### PR DESCRIPTION
Related to issue #58, this PR simplifies the code in the article template that handles looking for social media embeds: now it matches a URL on its own line and replaces it with the appropriate embed code. 

This was previously more complicated because of how Google Docs seems to handle URLs surrounded by plain text: they come through as a parent node with multiple children nodes, with the text broken up among them. Matching a URL on its own, regardless of whether it is hyperlinked in the doc or not, is a lot more straightforward.