### PR TITLE
Homepage featured stories

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -94,7 +94,7 @@ module.exports = {
               },
             },
           },
-          canonicalBaseUrl: 'http://tinynewsco.org/',
+          canonicalBaseUrl: 'https://tinynewsco.org/',
           components: ['amp-form'],
           excludedPaths: ['/404*', '/'],
           pathIdentifier: '/amp/',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,6 +7,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type Document implements Node {
       name: String!
       author: String
+      featured: Boolean
       createdTime: Date
       tags: [String]
       og_locale: String

--- a/src/components/GoogleLogin.js
+++ b/src/components/GoogleLogin.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { StaticQuery, graphql } from "gatsby"
 import { gapi, loadAuth2 } from 'gapi-script' 
 import queryString from 'query-string';
 import Layout from "../components/Layout"
@@ -24,11 +25,13 @@ class GoogleLogin extends Component {
         this.handleSubmit = this.handleSubmit.bind(this);
     }
 
+
     handleChangeDoc(event) {
       let data = this.state.doc;
       for (const key in data) {
         if (key === event.target.name) {
-          data[key] = event.target.value;
+          let value = event.target.name === "featured" ? event.target.checked : event.target.value;
+          data[key] = value;
         }
       }
       this.setState({doc: data});
@@ -98,9 +101,9 @@ class GoogleLogin extends Component {
     getDocData = (description) => {
       let docData;
       if ( (!description || /^\s*$/.test(description)) ) {
-        console.log("description is blank");
         docData = {
-          "author": "Ace Reporter",
+          "author": "",
+          "featured": false,
           "tags": ["news"],
           "og_type":"website",
           "og_title":"",
@@ -116,6 +119,10 @@ class GoogleLogin extends Component {
         }
       } else {
         docData = JSON.parse(description);
+      }
+      // default article to not being featured on the homepage
+      if (!Object.keys(docData).includes("featured")) {
+        docData["featured"] = false;
       }
       return docData;
     }
@@ -259,7 +266,12 @@ class GoogleLogin extends Component {
                 <div className="field-body">
                   <div className="field">
                     <div className="control">
-                      <input aria-label={key} name={key} className="input" type="text" value={this.state.doc[key] || ''} onChange={this.handleChangeDoc} />
+                      {(key === "featured") && 
+                        <input aria-label={key} name={key} type="checkbox" checked={this.state.doc[key] || false} onChange={this.handleChangeDoc} />
+                      }
+                      {(key !== "featured") && 
+                        <input aria-label={key} name={key} className="input" type="text" value={this.state.doc[key] || ''} onChange={this.handleChangeDoc} />
+                      }
                     </div>
                   </div>
                 </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,8 +20,12 @@ export default function HomePage({ data }) {
     getLCP(sendToGoogleAnalytics);
   }, []);
 
+  let allArticles = data.allGoogleDocs.nodes;
+  let featuredArticles = allArticles.filter(node => node.document.featured);
+  let unfeaturedArticles = allArticles.filter(node => !node.document.featured);
+
   let tags = [];
-  data.allGoogleDocs.nodes.forEach(({document}, index) => {
+  allArticles.forEach(({document}, index) => {
     tags = tags.concat(document.tags);
   })
   tags = _.uniq(tags).sort();
@@ -54,14 +58,14 @@ export default function HomePage({ data }) {
           </div>
         </section>
         <div className="featured-article">
-          {data.allGoogleDocs.nodes.slice(0, 1).map(({ document, childMarkdownRemark }, index) => (
+          {featuredArticles.map(({ document, childMarkdownRemark }, index) => (
             <FeaturedArticleLink key={document.path} document={document} excerpt={childMarkdownRemark.excerpt} /> 
           ))}
         </div>
         <section className="section">
           <div className="columns">
             <div className="column is-four-fifths">
-              {data.allGoogleDocs.nodes.slice(1).map(({ document, childMarkdownRemark }, index) => (
+              {unfeaturedArticles.map(({ document, childMarkdownRemark }, index) => (
                 <ArticleLink key={document.path} document={document} excerpt={childMarkdownRemark.excerpt} /> 
               ))}
             </div>
@@ -112,6 +116,7 @@ export const query = graphql`
             document {
               author
               createdTime
+              featured
               name
               path
               tags

--- a/src/pages/tinycms/index.js
+++ b/src/pages/tinycms/index.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { Link, graphql } from 'gatsby'
-import { parseISO, formatRelative } from 'date-fns'
 import Layout from "../../components/Layout"
 import "../styles.scss"
 
@@ -34,10 +33,17 @@ export default function Publish({ data }) {
       </nav>
     <Layout>
       <h1 className="title is-1">tinycms articles list</h1>
+      <p class="content">
+        To feature an article, click to edit and check the box next to <code>featured</code>. To un-feature an article, simply uncheck the box.
+      </p>
       <div>
         <ul>
           {data.allGoogleDocs.nodes.map(({ document, childMarkdownRemark }, index) => (
-            <li className="article-list-margin" key={index}><Link to={`/tinycms/edit?id=${document.id}`}>{document.name}</Link>
+            <li className="article-list-margin" key={index}>
+                {document.featured &&
+                  <span className="tag">Featured</span>
+                }
+              <Link to={`/tinycms/edit?id=${document.id}`}>{document.name}</Link>
               <ul>
                 <li>{childMarkdownRemark.excerpt}</li>
                 <li>Author: {document.author}</li>
@@ -64,6 +70,7 @@ export const query = graphql`
         document {
           author
           createdTime
+          featured
           id
           name
           path


### PR DESCRIPTION
Related to issue #62, this PR adds featured stories management (first pass).

* tinycms editor for each story includes a `featured` checkbox
* tinycms articles index flags featured stories with a `[featured]` tag
* homepage lists featured articles first using the `FeaturedArticleLink` component

Notes & caveats:

* more than one story can be featured
* if no stories are featured, all stories are given equivalent treatment on the homepage
* toggling a story as featured requires a restart to display locally; on tinynewsco.org that restart is handled automatically, but does take a couple minutes.

