### PR TITLE
Tiniest commit for tiny news: https all AMP urls

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -94,7 +94,7 @@ module.exports = {
               },
             },
           },
-          canonicalBaseUrl: 'http://tinynewsco.org/',
+          canonicalBaseUrl: 'https://tinynewsco.org/',
           components: ['amp-form'],
           excludedPaths: ['/404*', '/'],
           pathIdentifier: '/amp/',


### PR DESCRIPTION
A very tiny PR featuring a one character change: the canonical URL for AMP was using 'http' instead of 'https'

I tested this deploy in Netlify (see issue #72) and after changing the canonical URL, Netlify reports:

```
All linked resources are secure

Congratulations! No insecure mixed content found in your files.
```

Hooray :) 