### PR TITLE
Fix for double import of graphql

### DIFF
--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { graphql } from "gatsby"
-import { Link, graphql } from "gatsby"
 import ArticleNav from "../components/ArticleNav"
 import ArticleLink from "../components/ArticleLink"
 import Layout from "../components/Layout"


### PR DESCRIPTION
This fixes the error in gatsby develop & gatsby build:

```

 ERROR #98123  WEBPACK

Generating development JavaScript bundle failed


/Users/jacqui/Projects/newscatalyst/tinynewsdemo/src/templates/tag.js
  3:16  error  Parsing error: Identifier 'graphql' has already been declared

  1 | import React from "react"
  2 | import { graphql } from "gatsby"
> 3 | import { Link, graphql } from "gatsby"
    |                ^
  4 | import ArticleNav from "../components/ArticleNav"
  5 | import ArticleLink from "../components/ArticleLink"
  6 | import Layout from "../components/Layout"

✖ 1 problem (1 error, 0 warnings)


File: src/templates/tag.js

```