### PR TITLE
Site settings editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17891,6 +17891,15 @@
         "use-sidecar": "^1.0.1"
       }
     },
+    "react-google-login": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/react-google-login/-/react-google-login-5.1.20.tgz",
+      "integrity": "sha512-/5vDx8Hy7Wo1fO1VC/0e5D6/ZGWgIgvcscI8mYZUQ653QOFf0c4GhTnKkebX5uE7m5rAB/2bzzZIUlIesGqWig==",
+      "requires": {
+        "@types/react": "*",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-helmet": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-embed": "git+https://github.com/jacqui/react-embed.git",
+    "react-google-login": "^5.1.20",
     "react-helmet": "^6.0.0",
     "react-helmet-async": "^1.0.6",
     "react-player": "^2.1.1",

--- a/src/components/GoogleEdit.js
+++ b/src/components/GoogleEdit.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
-import { StaticQuery, graphql } from "gatsby"
 import { gapi, loadAuth2 } from 'gapi-script' 
 import queryString from 'query-string';
 import Layout from "../components/Layout"
 import "../pages/styles.scss"
 
-class GoogleLogin extends Component {
+class GoogleEdit extends Component {
     constructor(props) {
         super(props);
 
@@ -422,4 +421,4 @@ class GoogleLogin extends Component {
     }
 }
 
-export default GoogleLogin;
+export default GoogleEdit;

--- a/src/components/TinyCmsNav.js
+++ b/src/components/TinyCmsNav.js
@@ -1,0 +1,55 @@
+import React from "react"
+import _ from 'lodash'
+import { Link } from "gatsby"
+
+export default function TinyCmsNav(props) {
+
+return (
+    <nav className="navbar" role="navigation" aria-label="main navigation">
+      <div className="navbar-brand">
+        <a className="navbar-item" href="/tinycms">
+          tinycms
+        </a>
+
+        <a role="button" className="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample" href="/tinycms">
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
+      </div>
+
+      <div className="navbar-menu">
+        <div className="navbar-start">
+          <a className="navbar-item" href="/tinycms">
+            Articles
+          </a>
+
+          <a className="navbar-item" href="/tinycms/images">
+            Images
+          </a>
+
+          <a className="navbar-item" href="/tinycms/settings">
+            Settings
+          </a>
+        </div>
+
+        <div className="navbar-end">
+          <div className="navbar-item">
+            <div className="buttons">
+              {this.props.user && 
+                <button id="" className="button logout" onClick={this.props.signOut}>
+                  Log out
+                </button>
+              }
+              {!this.props.user && 
+                <button id="customBtn" className="button is-light">
+                  Log in
+                </button>
+              }   
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/TinyCmsNav.js
+++ b/src/components/TinyCmsNav.js
@@ -36,12 +36,12 @@ return (
         <div className="navbar-end">
           <div className="navbar-item">
             <div className="buttons">
-              {this.props.user && 
-                <button id="" className="button logout" onClick={this.props.signOut}>
+              {props.user && 
+                <button id="" className="button logout" onClick={props.signOut}>
                   Log out
                 </button>
               }
-              {!this.props.user && 
+              {!props.user && 
                 <button id="customBtn" className="button is-light">
                   Log in
                 </button>

--- a/src/components/TinyGoogleLogin.js
+++ b/src/components/TinyGoogleLogin.js
@@ -1,0 +1,56 @@
+import React, {Component} from 'react';
+let GoogleLib;
+export default class TinyGoogleLogin extends Component {
+    constructor () {
+        super();
+        this.state = { isSignedIn: false, showLoginButton: false, showLogoutButton: false, name: null, accessToken: null };
+    }
+    componentDidMount() {
+        GoogleLib = require('react-google-login');
+        this.setState({ showLoginButton: true, showLogoutButton: false });
+    }
+
+    // responseGoogleSuccess = (response) => {
+    //   this.setState({ isSignedIn: true, showLoginButton: false, showLogoutButton: true, name: response.profileObj.name, accessToken: response.accessToken })
+    //   console.log("responseGoogleSuccess: ", response);
+    // }
+
+    responseGoogle = (response) => {
+      console.log("responseGoogle: ", response);
+    }
+
+    logout = (response) => {
+      this.setState({ isSignedIn: false, showLoginButton: true, showLogoutButton: false, name: null, accessToken: null })
+      console.log("logout: ", response);
+    }
+
+    render() {
+        return (
+          <div>
+            <h1 className="title">testing google login</h1>
+            {this.state.name ?
+            <h1 className="subtitle">You are logged in as: {this.state.name}</h1>
+            : null}
+            {this.state.showLoginButton ?
+                <GoogleLib.GoogleLogin
+                    clientId={process.env.GATSBY_TINY_CMS_CLIENT_ID}
+                    buttonText="Login"
+                    onSuccess={this.props.successCb}
+                    onFailure={this.responseGoogle}
+                    cookiePolicy={'single_host_origin'}
+                    isSignedIn={true}
+                    scope="https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.metadata"
+                /> : null
+            }
+            {this.state.showLogoutButton ?
+              <GoogleLib.GoogleLogout
+                clientId={process.env.GATSBY_TINY_CMS_CLIENT_ID}
+                buttonText="Logout"
+                onLogoutSuccess={this.logout}
+              />
+              : null
+            }
+          </div>
+        );
+    }
+}

--- a/src/components/VerticalField.js
+++ b/src/components/VerticalField.js
@@ -20,17 +20,21 @@ export default function VerticalField(props) {
     props.updateSections(newSections)
   }
   return (
-    <div>
-      <div className="field">
-        <label className="label">Label</label>
-        <div className="control">
-          <input type="text" data-vertical-index={props.index} className="input" value={label} name="label" onChange={handleChange} />
+    <div className="columns">
+      <div className="column is-half">
+        <div className="field">
+          <label className="label">Label</label>
+          <div className="control">
+            <input type="text" data-vertical-index={props.index} className="input" value={label} name="label" onChange={handleChange} />
+          </div>
         </div>
       </div>
-      <div className="field">
-        <label className="label">Link</label>
-        <div className="control">
-          <input type="text" data-vertical-index={props.index} className="input" value={link} name="link" onChange={handleChange} />
+      <div className="column is-half">
+        <div className="field">
+          <label className="label">Link</label>
+          <div className="control">
+            <input type="text" data-vertical-index={props.index} className="input" value={link} name="link" onChange={handleChange} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/VerticalField.js
+++ b/src/components/VerticalField.js
@@ -1,0 +1,36 @@
+import React, {useState} from 'react';
+
+export default function VerticalField(props) {
+  console.log(props);
+
+  const [label, setLabel] = useState(props.label)
+  const [link, setLink] = useState(props.link);
+
+  const handleChange = e => {
+    console.log("handleChange sections: ", props.sections);
+    let name = e.target.name;
+    if (name === "label") {
+      setLabel(e.target.value);
+    } else if (name === "link") {
+      setLink(e.target.value);
+    }
+    // let newSections = props.sections.push({[label]: link})
+    // console.log("newSections: ", newSections)
+  }
+  return (
+    <div>
+      <div className="field">
+        <label className="label">Label</label>
+        <div className="control">
+          <input type="text" name={`label[${props.index}]`} className="input" value={label} name="label" onChange={handleChange} />
+        </div>
+      </div>
+      <div className="field">
+        <label className="label">Link</label>
+        <div className="control">
+          <input type="text" name={`link[${props.index}]`} className="input" value={link} name="link" onChange={handleChange} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/VerticalField.js
+++ b/src/components/VerticalField.js
@@ -7,28 +7,30 @@ export default function VerticalField(props) {
   const [link, setLink] = useState(props.link);
 
   const handleChange = e => {
-    console.log("handleChange sections: ", props.sections);
+    let newSections = props.sections;
+    let index = e.target.getAttribute("data-vertical-index");
     let name = e.target.name;
     if (name === "label") {
       setLabel(e.target.value);
+      newSections[index].label = e.target.value;
     } else if (name === "link") {
       setLink(e.target.value);
+      newSections[index].link = e.target.value;
     }
-    // let newSections = props.sections.push({[label]: link})
-    // console.log("newSections: ", newSections)
+    props.updateSections(newSections)
   }
   return (
     <div>
       <div className="field">
         <label className="label">Label</label>
         <div className="control">
-          <input type="text" name={`label[${props.index}]`} className="input" value={label} name="label" onChange={handleChange} />
+          <input type="text" data-vertical-index={props.index} className="input" value={label} name="label" onChange={handleChange} />
         </div>
       </div>
       <div className="field">
         <label className="label">Link</label>
         <div className="control">
-          <input type="text" name={`link[${props.index}]`} className="input" value={link} name="link" onChange={handleChange} />
+          <input type="text" data-vertical-index={props.index} className="input" value={link} name="link" onChange={handleChange} />
         </div>
       </div>
     </div>

--- a/src/pages/tinycms/edit.js
+++ b/src/pages/tinycms/edit.js
@@ -1,12 +1,12 @@
 
 import React from "react"
 import Layout from "../../components/Layout"
-import GoogleLogin from "../../components/GoogleLogin"
+import GoogleEdit from "../../components/GoogleEdit"
 
 const TinyEdit = () => {
   return (
     <Layout>
-      <GoogleLogin />
+      <GoogleEdit />
     </Layout>
   )
 }

--- a/src/pages/tinycms/index.js
+++ b/src/pages/tinycms/index.js
@@ -33,7 +33,7 @@ export default function Publish({ data }) {
       </nav>
     <Layout>
       <h1 className="title is-1">tinycms articles list</h1>
-      <p class="content">
+      <p className="content">
         To feature an article, click to edit and check the box next to <code>featured</code>. To un-feature an article, simply uncheck the box.
       </p>
       <div>

--- a/src/pages/tinycms/settings.js
+++ b/src/pages/tinycms/settings.js
@@ -10,24 +10,36 @@ export default function TinySettings({data}) {
     email: null
   });
   const [sections, setSections] = useState([]);
+  const [message, setMessage] = useState(null);
+  const [error, setError] = useState(null);
 
   let settingsDoc = data.allGoogleDocs.nodes[0];
   let settingsDocID = settingsDoc.document.id;
 
   const handleSubmit = event => {
     event.preventDefault();
-    console.log("handleSubmit sections: ", sections);
     let docData = { "sections": sections };
     let docContentString = JSON.stringify(docData);
     console.log("new doc contents: ", docContentString);
 
-    gapi.client.drive.files.update({'fileId': settingsDocID, 'method': 'PATCH', 'body': docContentString})
+    let path = `/upload/drive/v3/files/${settingsDocID}`;
+    // gapi.client.drive.files.update({'fileId': settingsDocID, 'method': 'PATCH', 'body': docContentString})
+    gapi.client.request({
+      'path': path,
+      'method': "PATCH",
+      'params': { 'uploadType': 'media'},
+      'body': docContentString
+    })
     .then((response) => {
       // Handle response
       console.log("update google doc response: ", response);
+      setError(null);
+      setMessage("Updated settings.")
     }, (reason) => {
       // Handle error
       console.log("update google doc error: ", reason);
+      setMessage(null);
+      setError("An error occurred while updating the settings.")
     });
   }
 
@@ -90,21 +102,47 @@ export default function TinySettings({data}) {
   return (
     <div>
       <TinyCmsNav user={user} signOut={signOut} />
-      <h1 className="title">tinycms settings</h1>
+      <h1 className="title is-size-1">tinycms settings</h1>
       <p>
         Configure various aspects of the tinynewsco site here.
       </p>
 
-      <section className="section">
-        <h2 className="is-2">Verticals</h2>
-        <form onSubmit={handleSubmit}>
-          {verticalItems}
-          <div className="field is-grouped">
-            <div className="control">
-              <input type="submit" className="button is-link" value="Submit" />
+      { message && 
+        <div className="message is-success">
+            <div className="message-header">
+              Success
             </div>
-            <div className="control">
-              <button className="button is-link is-light">Cancel</button>
+            <div className="message-body">
+              {message}
+            </div>
+        </div>
+      }
+      {error &&
+        <div className="message is-danger">
+            <div className="message-header">
+              Error
+            </div>
+            <div className="message-body">
+              {error}
+            </div>
+        </div>
+      }
+      <section className="section">
+        <h2 className="title is-size-2">Sections</h2>
+        <form onSubmit={handleSubmit}>
+
+          <div className="container" style={ {marginBottom: '1rem' }}>
+            {verticalItems}
+          </div>
+
+          <div className="container">
+            <div className="field is-grouped">
+              <div className="control">
+                <input type="submit" className="button is-link" value="Submit" />
+              </div>
+              <div className="control">
+                <button className="button is-link is-light">Cancel</button>
+              </div>
             </div>
           </div>
         </form>

--- a/src/pages/tinycms/settings.js
+++ b/src/pages/tinycms/settings.js
@@ -1,0 +1,92 @@
+import React, {useEffect, useState} from 'react';
+import { gapi, loadAuth2 } from 'gapi-script' 
+import { graphql } from "gatsby"
+// import { fetchUser } from '../utils/google.js'
+
+export default function TinySettings({data}) {
+  const [user, setUser] = useState({
+    name: null,
+    email: null
+  });
+
+  let settingsDoc = data.allGoogleDocs.nodes[0];
+
+  let settingsDocID = settingsDoc.document.id;
+  let settingsContents = settingsDoc.childMarkdownRemark.rawMarkdownBody;
+
+  let scopes = "https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.metadata";
+
+  useEffect(
+    () => {
+      async function fetchUser() {
+        let userData;
+        let auth2 = await loadAuth2(process.env.GATSBY_TINY_CMS_CLIENT_ID, scopes);
+        if (auth2.isSignedIn.get()) {
+          userData = auth2.currentUser.get().getBasicProfile();
+          console.log("userData: ", userData)
+          setUser({name: userData.getName(), email: userData.getEmail()})
+        }
+      }
+      fetchUser();
+
+      // LOAD Google Drive API client libraries
+      gapi.load('client', () => {
+
+        // INITIALISE Google Drive API Client
+        gapi.client.init({
+          'apiKey': process.env.GATSBY_TINY_CMS_API_KEY,
+          'clientId': process.env.GATSBY_TINY_CMS_CLIENT_ID,
+          'scope': scopes,
+        }).then(function() {
+          console.log("initialized google drive api client")
+          // BUILD path to document data endpoint for gapi requests
+          let path = `/drive/v3/files/${settingsDocID}?fields=description,name`;
+
+          // GET document metadata from Google Drive
+          return gapi.client.request({
+            'path': path,
+            'method': 'GET'
+          })
+        }).then(response => {
+          console.log("found settings document: ", response)
+        });
+      });
+  }, []);
+
+  function signOut() {
+    let auth2 = gapi.auth2.getAuthInstance();
+    auth2.signOut().then(() => {
+        this.setState({ user: null })
+    });
+  }
+  return (
+    <div>
+      <TinyCmsNav user={user} signOut={signOut} />
+      <h1 className="title">tinycms settings</h1>
+      <p>
+        Configure various aspects of the tinynewsco site here.
+      </p>
+      <pre>
+        {settingsContents}
+      </pre>
+      <p>
+        You are logged in as: {username} ({email})
+      </p>
+    </div>
+  );
+}
+
+export const query = graphql`
+  query MyQuery {
+    allGoogleDocs(filter: {document: {name: {eq: "settings"}}}) {
+      nodes {
+        document {
+          id
+        }
+        childMarkdownRemark {
+          rawMarkdownBody
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
This PR creates a new "settings editor" in the tiny news co "cms" that allows management of site-wide content, starting with global sections (aka categories or verticals).

It's achieving this by storing the data in JSON in a special google doc called "settings" - this doc is omitted from the articles list.

I think we could expand this in the future to allow for editing of other site data that currently lives in `gatsby-config.js` - depending on how we decide to handle internationalisation.