### PR TITLE
Create section pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -81,6 +81,20 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         })
       })
 
+      console.log("Making ", sections.length, " section pages...")
+      sections.forEach(section => {
+  
+        actions.createPage({
+          path: section.link,
+          component: path.resolve(`./src/templates/section.js`),
+          context: {
+            category: section.label,
+            section: section,
+            sections: sections,
+          },
+        })
+        console.log(" - created ", section.link)
+      })
 
       // remove any null tags
       tags = tags.filter(function (el) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,7 +39,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     }`
   ).then(result => {
     let settingsJson = result.data.allGoogleDocs.nodes[0].childMarkdownRemark.rawMarkdownBody;
-    console.log("found settings JSON: ", settingsJson);
     let settings = JSON.parse(settingsJson);
     sections = settings.sections;
   });
@@ -58,7 +57,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         }
     `
   ).then(result => {
-    console.log("working with how many sections: ", sections.length)
       let tags = []
       result.data.allGoogleDocs.nodes.forEach(({document}, index) => {
         tags = tags.concat(document.tags);
@@ -90,7 +88,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       });
 
       tags = _.uniq(tags)
-      console.log(tags);
+
       console.log("Making", tags.length, "tag pages...")
       tags.forEach(tag => {
         const tagPath = `/topics/${_.kebabCase(tag)}/`

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,7 +25,25 @@ exports.createSchemaCustomization = ({ actions }) => {
   createTypes(typeDefs)
 }
 
+let sections = [];
 exports.createPages = async ({ actions, graphql, reporter }) => {
+  graphql(
+    `{
+      allGoogleDocs(filter: {document: {name: {eq: "settings"}}}) {
+        nodes {
+          childMarkdownRemark {
+            rawMarkdownBody
+          }
+        }
+      }
+    }`
+  ).then(result => {
+    let settingsJson = result.data.allGoogleDocs.nodes[0].childMarkdownRemark.rawMarkdownBody;
+    console.log("found settings JSON: ", settingsJson);
+    let settings = JSON.parse(settingsJson);
+    sections = settings.sections;
+  });
+
   graphql(
     `
         {
@@ -40,6 +58,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         }
     `
   ).then(result => {
+    console.log("working with how many sections: ", sections.length)
       let tags = []
       result.data.allGoogleDocs.nodes.forEach(({document}, index) => {
         tags = tags.concat(document.tags);
@@ -49,6 +68,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             component: path.resolve(`./src/templates/post.js`),
             context: {
               slug: document.path,
+              sections: sections,
             }
         })
 
@@ -58,6 +78,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           component: path.resolve('./src/templates/post.js'),
           context: {
             slug: document.path,
+            sections: sections,
           }
         })
       })
@@ -79,6 +100,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           component: path.resolve(`./src/templates/tag.js`),
           context: {
             tag,
+            sections,
           },
         })
         console.log(" - created ", tagPath)

--- a/src/components/ArticleNav.js
+++ b/src/components/ArticleNav.js
@@ -4,6 +4,15 @@ import { Link } from "gatsby"
 
 export default function ArticleNav(props) {
   let tagLinks;
+  let sectionLinks;
+
+  if (props.sections) {
+    sectionLinks = props.sections.slice(0,4).map(section => (
+      <Link key={`navbar-${_.kebabCase(section.label)}`} to={section.link} className="navbar-item">
+        {_.startCase(section.label)}
+      </Link>
+    ));
+  }
 
   if (props.tags) {
     tagLinks = props.tags.slice(0,4).map(tag => (
@@ -29,7 +38,7 @@ export default function ArticleNav(props) {
       <div className="navbar-menu">
         <div className="navbar-start">
           
-          {tagLinks}
+          {sectionLinks}
 
           <a className="navbar-item" href="/topics">
             {props.metadata.nav.topics}

--- a/src/components/GoogleEdit.js
+++ b/src/components/GoogleEdit.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { gapi, loadAuth2 } from 'gapi-script' 
+import { gapi, loadAuth2 } from 'gapi-script'
 import queryString from 'query-string';
 import Layout from "../components/Layout"
 import "../pages/styles.scss"
@@ -10,7 +10,7 @@ class GoogleEdit extends Component {
 
         this.state = {
           id: '',
-          categories: props.settingsData.sections,
+          sections: props.settingsData.sections,
           doc: { },
           newField: '',
           message: '',
@@ -47,7 +47,7 @@ class GoogleEdit extends Component {
       if (typeof(docData.tags) === "string") {
         docData.tags = docData.tags.split(',')
       }
-      let bodyForGoogle = { 
+      let bodyForGoogle = {
         description: JSON.stringify(docData)
       }
 
@@ -103,7 +103,7 @@ class GoogleEdit extends Component {
       if ( (!description || /^\s*$/.test(description)) ) {
         docData = {
           "author": "",
-          "category": "",
+          "section": "",
           "featured": false,
           "og_type":"website",
           "og_title":"",
@@ -125,8 +125,8 @@ class GoogleEdit extends Component {
       if (!Object.keys(docData).includes("featured")) {
         docData["featured"] = false;
       }
-      if (!Object.keys(docData).includes("category")) {
-        docData["category"] = "";
+      if (!Object.keys(docData).includes("section")) {
+        docData["section"] = "";
       }
       return docData;
     }
@@ -226,7 +226,7 @@ class GoogleEdit extends Component {
         if (idx !== fidx) return field;
         return { ...field, name: evt.target.value };
       });
-  
+
       this.setState({ fields: newFields });
     };
 
@@ -258,8 +258,8 @@ class GoogleEdit extends Component {
     }
 
     render() {
-      let categoryOptions = this.state.categories.map((category, index) => (
-        <option value={category.label} key={`section-option-${index}`}>{category.label}</option>
+      let sectionOptions = this.state.sections.map((section, index) => (
+        <option value={section.label} key={`section-option-${index}`}>{section.label}</option>
       ));
 
         if(this.state.user) {
@@ -274,18 +274,18 @@ class GoogleEdit extends Component {
                 <div className="field-body">
                   <div className="field">
                     <div className="control">
-                      {(key === "featured") && 
+                      {(key === "featured") &&
                         <input aria-label={key} name={key} type="checkbox" checked={this.state.doc[key] || false} onChange={this.handleChangeDoc} />
                       }
-                      {(key === "category") && 
+                      {(key === "section") &&
                         <div className="select">
-                          <select name="category" value={this.state.doc["category"]} onChange={this.handleChangeDoc}>
+                          <select name="section" value={this.state.doc["section"]} onChange={this.handleChangeDoc}>
                             <option>Please select...</option>
-                            {categoryOptions}
+                            {sectionOptions}
                           </select>
                         </div>
                       }
-                      {(key !== "featured" && key !== "category") && 
+                      {(key !== "featured" && key !== "section") &&
                         <input aria-label={key} name={key} className="input" type="text" value={this.state.doc[key] || ''} onChange={this.handleChangeDoc} />
                       }
                     </div>
@@ -328,16 +328,16 @@ class GoogleEdit extends Component {
                     <div className="navbar-end">
                       <div className="navbar-item">
                         <div className="buttons">
-                          {this.state.user && 
+                          {this.state.user &&
                             <button id="" className="button logout" onClick={this.signOut}>
                               Log out
                             </button>
                           }
-                          {!this.state.user && 
+                          {!this.state.user &&
                             <button id="customBtn" className="button is-light">
                               Log in
                             </button>
-                          }   
+                          }
                         </div>
                       </div>
                     </div>
@@ -367,7 +367,7 @@ class GoogleEdit extends Component {
                       </div>
                   </div>}
 
-                { this.state.docLoaded && 
+                { this.state.docLoaded &&
                   <section className="section">
 
                     <form onSubmit={this.handleSubmit}>
@@ -419,16 +419,16 @@ class GoogleEdit extends Component {
                     <div className="navbar-end">
                       <div className="navbar-item">
                         <div className="buttons">
-                          {this.state.user && 
+                          {this.state.user &&
                             <button id="" className="button logout" onClick={this.signOut}>
                               Log out
                             </button>
                           }
-                          {!this.state.user && 
+                          {!this.state.user &&
                             <button id="customBtn" className="button is-light">
                               Log in
                             </button>
-                          }   
+                          }
                         </div>
                       </div>
                     </div>

--- a/src/components/GoogleEdit.js
+++ b/src/components/GoogleEdit.js
@@ -10,6 +10,7 @@ class GoogleEdit extends Component {
 
         this.state = {
           id: '',
+          categories: props.settingsData.sections,
           doc: { },
           newField: '',
           message: '',
@@ -102,8 +103,8 @@ class GoogleEdit extends Component {
       if ( (!description || /^\s*$/.test(description)) ) {
         docData = {
           "author": "",
+          "category": "",
           "featured": false,
-          "tags": ["news"],
           "og_type":"website",
           "og_title":"",
           "og_description":"",
@@ -112,6 +113,7 @@ class GoogleEdit extends Component {
           "og_image_alt": "",
           "og_url":"",
           "og_site_name":"",
+          "tags": ["news"],
           "tw_handle":"@",
           "tw_site":"@",
           "tw_cardType":"summary_large_image"
@@ -122,6 +124,9 @@ class GoogleEdit extends Component {
       // default article to not being featured on the homepage
       if (!Object.keys(docData).includes("featured")) {
         docData["featured"] = false;
+      }
+      if (!Object.keys(docData).includes("category")) {
+        docData["category"] = "";
       }
       return docData;
     }
@@ -253,6 +258,10 @@ class GoogleEdit extends Component {
     }
 
     render() {
+      let categoryOptions = this.state.categories.map((category, index) => (
+        <option value={category.label} key={`section-option-${index}`}>{category.label}</option>
+      ));
+
         if(this.state.user) {
           let formFields = [];
           if (this.state.docLoaded) {
@@ -268,7 +277,15 @@ class GoogleEdit extends Component {
                       {(key === "featured") && 
                         <input aria-label={key} name={key} type="checkbox" checked={this.state.doc[key] || false} onChange={this.handleChangeDoc} />
                       }
-                      {(key !== "featured") && 
+                      {(key === "category") && 
+                        <div className="select">
+                          <select name="category" value={this.state.doc["category"]} onChange={this.handleChangeDoc}>
+                            <option>Please select...</option>
+                            {categoryOptions}
+                          </select>
+                        </div>
+                      }
+                      {(key !== "featured" && key !== "category") && 
                         <input aria-label={key} name={key} className="input" type="text" value={this.state.doc[key] || ''} onChange={this.handleChangeDoc} />
                       }
                     </div>
@@ -301,6 +318,10 @@ class GoogleEdit extends Component {
 
                       <a className="navbar-item" href="/tinycms/images">
                         Images
+                      </a>
+
+                      <a className="navbar-item" href="/tinycms/settings">
+                        Settings
                       </a>
                     </div>
 
@@ -388,6 +409,10 @@ class GoogleEdit extends Component {
 
                       <a className="navbar-item" href="/tinycms/images">
                         Images
+                      </a>
+
+                      <a className="navbar-item" href="/tinycms/settings">
+                        Settings
                       </a>
                     </div>
 

--- a/src/pages/tinycms/edit.js
+++ b/src/pages/tinycms/edit.js
@@ -3,12 +3,26 @@ import React from "react"
 import Layout from "../../components/Layout"
 import GoogleEdit from "../../components/GoogleEdit"
 
-const TinyEdit = () => {
+const TinyEdit = ({data}) => {
+  let settingsJson = data.allGoogleDocs.nodes[0].childMarkdownRemark.rawMarkdownBody;
+  let settings = JSON.parse(settingsJson);
+
   return (
     <Layout>
-      <GoogleEdit />
+      <GoogleEdit settingsData={settings} />
     </Layout>
   )
 }
 
 export default TinyEdit
+
+export const settingsQuery = graphql`
+  query {
+      allGoogleDocs(filter: {document: {name: {eq: "settings"}}}) {
+        nodes {
+          childMarkdownRemark {
+            rawMarkdownBody
+          }
+        }
+      }
+    }`

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -60,7 +60,6 @@ const canEmbedStreamable = (url) => MATCH_URL_STREAMABLE.test(url);
 
 function isValidUrl(url) {
   let validUrl = urlRegex.test(url);
-  console.log(url, "is it valid? ", validUrl);
   if (!validUrl) {
     return false; // don't bother processing further
   }
@@ -78,7 +77,6 @@ function isValidUrl(url) {
     canEmbedYoutube(url) || 
     canEmbedVimeo(url) );
 
-  console.log(url, "is it supported? ", supportedPlatform);
   return validUrl && supportedPlatform;
 }
 
@@ -123,6 +121,7 @@ export default class Posttest extends React.Component {
   }
 
   render () {
+    let sections = this.props.pageContext.sections;
     let data = this.props.data;
     let doc = data.googleDocs.document;
     let parsedDate = parseISO(doc.createdTime)
@@ -134,7 +133,7 @@ export default class Posttest extends React.Component {
     }
     return (
       <div id="article-container">
-        <ArticleNav metadata={data.site.siteMetadata} />
+        <ArticleNav metadata={data.site.siteMetadata} sections={sections} />
         <Layout title={doc.name} description={data.googleDocs.childMarkdownRemark.excerpt} {...doc}>
           <article>
             <section className="hero is-bold">

--- a/src/templates/section.js
+++ b/src/templates/section.js
@@ -1,0 +1,68 @@
+import React from "react"
+import { graphql } from "gatsby"
+import ArticleNav from "../components/ArticleNav"
+import ArticleLink from "../components/ArticleLink"
+import Layout from "../components/Layout"
+import Footer from "../components/Footer"
+import "../pages/styles.scss"
+
+class Section extends React.Component {
+  render() {
+    let data = this.props.data;
+    let sections = this.props.pageContext.sections;
+    let sectionHeader = this.props.pageContext.section.label + " Articles";
+    
+    return (
+      <div>
+        <ArticleNav metadata={data.site.siteMetadata} sections={sections} />
+        <Layout>
+          <section className="section">
+            <h3 className="title is-size-4 is-bold-light">{sectionHeader}</h3>
+            {data.allGoogleDocs.nodes.map(({ document, childMarkdownRemark }, index) => (
+              <ArticleLink key={document.path} document={document} excerpt={childMarkdownRemark.excerpt} /> 
+            ))}
+          </section>
+        </Layout>
+        <Footer post_type="tag" metadata={data.site.siteMetadata} />
+      </div>
+    )
+  }
+}
+
+export default Section;
+
+export const sectionPageQuery = graphql`
+  query SectionPage($category: String) {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        nav {
+          articles
+          topics
+          cms
+        }
+      }
+    }
+    allGoogleDocs(filter: {document: {category: {eq: $category}}}) {
+      nodes {
+        document {
+          id
+          author
+          category
+          createdTime
+          name
+          path
+        }
+        childMarkdownRemark {
+          excerpt(truncate: true, format: PLAIN, pruneLength: 100)
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
This PR wraps up the work on issue #61, creating section pages for each defined "section" (aka category or vertical).

Sections are defined in the tinycms settings.

They're used to build the links in the top navbar.

Clicking each should bring you to the section page, which for now lists articles assigned to that section. You're currently limited to one section per article. Otherwise these would be the same as tags, I guess.

Note: I probably have used section, category and vertical interchangeably in the code and UI. I'll need to review this after a little break because I'm at the point in my day of no longer knowing what words mean 🙄