### PR TITLE
AMP-related fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,32 +76,6 @@ module.exports = {
           },
         },
       },
-
-      {
-        resolve: `gatsby-plugin-amp`,
-        options: {
-          analytics: {
-            type: 'gtag',
-            dataCredentials: 'include',
-            config: {
-              vars: {
-                gtag_id: "UA-166777432-1",
-                config: {
-                  "UA-166777432-1": {
-                    page_location: '{{pathname}}'
-                  },
-                },
-              },
-            },
-          },
-          canonicalBaseUrl: 'https://tinynewsco.org/',
-          components: ['amp-form'],
-          excludedPaths: ['/404*', '/'],
-          pathIdentifier: '/amp/',
-          relAmpHtmlPattern: '{{canonicalBaseUrl}}{{pathname}}{{pathIdentifier}}',
-          useAmpClientIdApi: true,
-        },
-      },
       {
         resolve: 'gatsby-plugin-mailchimp',
         options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -70,7 +70,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       });
 
       tags = _.uniq(tags)
-      console.log(tags);
+
       console.log("Making", tags.length, "tag pages...")
       tags.forEach(tag => {
         const tagPath = `/topics/${_.kebabCase(tag)}/`

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -83,6 +83,16 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           },
         })
         console.log(" - created ", tagPath)
+
+        actions.createPage({
+          path: tagPath,
+          path: `${tagPath}amp/`,
+          component: path.resolve(`./src/templates/tag.amp.js`),
+          context: {
+            tag,
+          },
+        })
+        console.log(" - created ", `${tagPath}amp/`)
       })
   })
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -43,7 +43,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       let tags = []
       result.data.allGoogleDocs.nodes.forEach(({document}, index) => {
         tags = tags.concat(document.tags);
-        console.log("creating page for google doc at ", document.path)
+        console.log("creating page for article at ", document.path)
         actions.createPage({
             path: document.path,
             component: path.resolve(`./src/templates/article.js`),
@@ -52,7 +52,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             }
         })
 
-        console.log("creating amp page for google doc at ", `${document.path}/amp/`)
+        console.log("creating AMP page for article at ", `${document.path}/amp/`)
         actions.createPage({
           path: `${document.path}/amp/`,
           component: path.resolve('./src/templates/article.amp.js'),
@@ -82,7 +82,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             tag,
           },
         })
-        console.log(" - created ", tagPath)
+        console.log("creating tag page at ", tagPath)
 
         actions.createPage({
           path: tagPath,
@@ -92,8 +92,22 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             tag,
           },
         })
-        console.log(" - created ", `${tagPath}amp/`)
+        console.log("creating tag page for AMP at ", `${tagPath}amp/`)
       })
+
+      // create topics index page
+      actions.createPage({
+        path: "/topics/",
+        component: path.resolve(`./src/templates/topics.js`),
+      })
+      console.log("creating topics index page at /topics/")
+
+      // create topics index page - AMP
+      actions.createPage({
+        path: "/topics/amp/",
+        component: path.resolve(`./src/templates/topics.amp.js`),
+      })
+      console.log("creating topics index page for AMP at /topics/amp/")
   })
 
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -46,7 +46,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         console.log("creating page for google doc at ", document.path)
         actions.createPage({
             path: document.path,
-            component: path.resolve(`./src/templates/post.js`),
+            component: path.resolve(`./src/templates/article.js`),
             context: {
               slug: document.path,
             }
@@ -55,9 +55,10 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         console.log("creating amp page for google doc at ", `${document.path}/amp/`)
         actions.createPage({
           path: `${document.path}/amp/`,
-          component: path.resolve('./src/templates/post.js'),
+          component: path.resolve('./src/templates/article.amp.js'),
           context: {
             slug: document.path,
+            amp: true,
           }
         })
       })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -108,6 +108,20 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         component: path.resolve(`./src/templates/topics.amp.js`),
       })
       console.log("creating topics index page for AMP at /topics/amp/")
+
+      // create subscribe page
+      actions.createPage({
+        path: "/subscribe/",
+        component: path.resolve(`./src/templates/subscribe.js`),
+      })
+      console.log("creating newsletter subscribe page at /subscribe/")
+
+      // create subscribe page - AMP
+      actions.createPage({
+        path: "/subscribe/amp/",
+        component: path.resolve(`./src/templates/subscribe.amp.js`),
+      })
+      console.log("creating newsletter subscribe page for AMP at /subscribe/amp/")
   })
 
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -76,11 +76,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           component: path.resolve('./src/templates/article.amp.js'),
           context: {
             slug: document.path,
-<<<<<<< HEAD
             amp: true,
-=======
             sections: sections,
->>>>>>> develop
           }
         })
       })
@@ -96,7 +93,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       console.log("Making", tags.length, "tag pages...")
       tags.forEach(tag => {
         const tagPath = `/topics/${_.kebabCase(tag)}/`
-  
+
         actions.createPage({
           path: tagPath,
           component: path.resolve(`./src/templates/tag.js`),

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,34 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, shrink-to-fit=no" />
+
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from 'gatsby'
+import { graphql, Link } from 'gatsby'
 import ArticleNav from "../components/ArticleNav"
 import Layout from "../components/Layout"
 import Footer from "../components/Footer"

--- a/src/templates/article.amp.js
+++ b/src/templates/article.amp.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { Helmet } from 'react-helmet'
 import _ from 'lodash'
 import { graphql, Link } from "gatsby"
 import { parseISO, formatRelative } from 'date-fns'
@@ -106,14 +107,18 @@ const processingInstructions = [
   }
 ];
 
-export default class Posttest extends React.Component {
+export default class ArticleAMP extends React.Component {
   state = {
-    articleHtml: null,
+    articleHtml: this.props.data.googleDocs.childMarkdownRemark.html,
   }
   componentDidMount() {
     let updatedHtml = htmlParser.parseWithInstructions(this.props.data.googleDocs.childMarkdownRemark.html, isValidNode, processingInstructions);
+
+    let canonicalUrl = window.location.href.replace("/amp/", "");
+
     this.setState({
       articleHtml: updatedHtml,
+      canonicalUrl: canonicalUrl,
     })
     getCLS(sendToGoogleAnalytics);
     getFID(sendToGoogleAnalytics);
@@ -125,15 +130,23 @@ export default class Posttest extends React.Component {
     let doc = data.googleDocs.document;
     let parsedDate = parseISO(doc.createdTime)
 
-
     let tagLinks;
     if (doc.tags) {
       tagLinks = doc.tags.map((tag, index) => (
         <Link to={`/topics/${_.kebabCase(tag)}`} key={`${tag}-${index}`} className="is-link tag">{tag}</Link>
       ))
     }
+
     return (
       <div id="article-container">
+        <Helmet
+          htmlAttributes={{ amp: true, lang: 'en' }}
+        >
+          <meta charset="utf-8" />
+          <script async src="https://cdn.ampproject.org/v0.js"></script>
+          <link rel="canonical" href={this.state.canonicalUrl} /> // ⚡ Add canonical
+        </Helmet>
+
         <ArticleNav metadata={data.site.siteMetadata} />
         <Layout title={doc.name} description={data.googleDocs.childMarkdownRemark.excerpt} {...doc}>
           <article>
@@ -150,7 +163,7 @@ export default class Posttest extends React.Component {
               </div>
             </section>
             {doc.cover &&
-              <amp-img src={doc.cover.image} alt={doc.cover.title} className="image" layout="responsive" />
+              <amp-img src={doc.cover.image} width="1600" height="1000" alt={doc.cover.title} className="image" layout="responsive" />
             }
             <section className="section">
               <div className="content">

--- a/src/templates/article.amp.js
+++ b/src/templates/article.amp.js
@@ -1,0 +1,242 @@
+import React from "react"
+import _ from 'lodash'
+import { graphql, Link } from "gatsby"
+import { parseISO, formatRelative } from 'date-fns'
+import Embed from 'react-embed';
+import {getCLS, getFID, getLCP} from 'web-vitals';
+import { Parser, ProcessNodeDefinitions } from "html-to-react";
+import ArticleFooter from "../components/ArticleFooter"
+import ArticleNav from "../components/ArticleNav"
+import Layout from "../components/Layout"
+import SignUp from "../components/SignUp"
+import sendToGoogleAnalytics from "../utils/vitals"
+import "../pages/styles.scss"
+
+// Look for URLs in the article copy for embedding social media
+let urlRegex = /(https?:\/\/)?([\w\-])+\.{1}([a-zA-Z]{2,63})([\/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)/i; 
+
+const MATCH_URL_DAILY_MOTION = /^(?:(?:https?):)?(?:\/\/)?(?:www\.)?(?:(?:dailymotion\.com(?:\/embed)?\/video)|dai\.ly)\/([a-zA-Z0-9]+)(?:_[\w_-]+)?$/;
+const canEmbedDailyMotion = (url) => MATCH_URL_DAILY_MOTION.test(url);
+
+const MATCH_URL_FACEBOOK = /facebook\.com\/.+/;
+const canEmbedFacebook = (url) => MATCH_URL_FACEBOOK.test(url);
+
+const MATCH_URL_GOOGLE = /google\.com\/.+/;
+const canEmbedGoogle = (url) => MATCH_URL_GOOGLE.test(url);
+
+const MATCH_URL_INSTAGRAM = /instagram\.com\/.+/;
+const canEmbedInstagram = (url) => MATCH_URL_INSTAGRAM.test(url);
+
+const MATCH_URL_IMGUR = /imgur\.com\/.+/;
+const canEmbedImgur = (url) => MATCH_URL_IMGUR.test(url);
+
+const MATCH_URL_MIXCLOUD = /mixcloud\.com\/([^/]+\/[^/]+)/;
+const canEmbedMixcloud = (url) => MATCH_URL_MIXCLOUD.test(url);
+
+const MATCH_VIDEO_URL_TWITCH = /(?:www\.|go\.)?twitch\.tv\/videos\/(\d+)($|\?)/;
+const MATCH_CHANNEL_URL_TWITCH = /(?:www\.|go\.)?twitch\.tv\/([a-z0-9_]+)($|\?)/;
+const canEmbedTwitch = (url) => MATCH_VIDEO_URL_TWITCH.test(url) || MATCH_CHANNEL_URL_TWITCH.test(url);
+
+const MATCH_URL_TWITTER = /twitter\.com\/.+/;
+const canEmbedTwitter = (url) => MATCH_URL_TWITTER.test(url);
+
+const MATCH_URL_YOUTUBE = /(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})|youtube\.com\/playlist\?list=/
+const canEmbedYoutube = url => MATCH_URL_YOUTUBE.test(url);
+
+const MATCH_URL_VIMEO = /vimeo\.com\/.+/;
+const MATCH_FILE_URL_VIMEO = /vimeo\.com\/external\/.+\.mp4/;
+const canEmbedVimeo = (url) => {
+  if (MATCH_FILE_URL_VIMEO.test(url)) {
+    return false;
+  }
+  return MATCH_URL_VIMEO.test(url);
+};
+
+const MATCH_URL_SOUNDCLOUD = /(soundcloud\.com|snd\.sc)\/.+$/;
+const canEmbedSoundcloud = url => MATCH_URL_SOUNDCLOUD.test(url);
+
+const MATCH_URL_STREAMABLE = /streamable\.com\/([a-z0-9]+)$/;
+const canEmbedStreamable = (url) => MATCH_URL_STREAMABLE.test(url);
+
+function isValidUrl(url) {
+  let validUrl = urlRegex.test(url);
+  if (!validUrl) {
+    return false; // don't bother processing further
+  }
+  let supportedPlatform = ( 
+    canEmbedDailyMotion(url) || 
+    canEmbedFacebook(url) ||
+    canEmbedGoogle(url) || 
+    canEmbedImgur(url) || 
+    canEmbedInstagram(url) ||
+    canEmbedMixcloud(url) || 
+    canEmbedSoundcloud(url) || 
+    canEmbedStreamable(url) || 
+    canEmbedTwitch(url) ||
+    canEmbedTwitter(url) || 
+    canEmbedYoutube(url) || 
+    canEmbedVimeo(url) );
+
+  return validUrl && supportedPlatform;
+}
+
+const htmlParser = new Parser(React);
+const processNodeDefinitions = new ProcessNodeDefinitions(React);
+function isValidNode(){
+    return true;
+}
+const processingInstructions = [
+  // first, should this block become an embed? try matching against URL regex
+  {
+      shouldProcessNode: (node) => {
+        let foundMatch = (node.data && isValidUrl(node.data));
+        return foundMatch;
+  },
+  // processNode gets executed if shouldProcessNode returns true
+  // this replaces the URL with an embed
+      processNode: (node) => {
+        let embedUrl = node.data;
+        return <Embed width={560} url={embedUrl} />
+      }
+  },
+  // Default processing
+  {
+      shouldProcessNode: () => true,
+      processNode: processNodeDefinitions.processDefaultNode
+  }
+];
+
+export default class Posttest extends React.Component {
+  state = {
+    articleHtml: null,
+  }
+  componentDidMount() {
+    let updatedHtml = htmlParser.parseWithInstructions(this.props.data.googleDocs.childMarkdownRemark.html, isValidNode, processingInstructions);
+    this.setState({
+      articleHtml: updatedHtml,
+    })
+    getCLS(sendToGoogleAnalytics);
+    getFID(sendToGoogleAnalytics);
+    getLCP(sendToGoogleAnalytics);
+  }
+
+  render () {
+    let data = this.props.data;
+    let doc = data.googleDocs.document;
+    let parsedDate = parseISO(doc.createdTime)
+
+
+    let tagLinks;
+    if (doc.tags) {
+      tagLinks = doc.tags.map((tag, index) => (
+        <Link to={`/topics/${_.kebabCase(tag)}`} key={`${tag}-${index}`} className="is-link tag">{tag}</Link>
+      ))
+    }
+    return (
+      <div id="article-container">
+        <ArticleNav metadata={data.site.siteMetadata} />
+        <Layout title={doc.name} description={data.googleDocs.childMarkdownRemark.excerpt} {...doc}>
+          <article>
+            <section className="hero is-bold">
+              <div className="hero-body">
+                <div className={doc.cover ? "container head-margin" : "container"}>
+                  <h1 className="title is-size-1">
+                    {doc.name}
+                  </h1>
+                  <h2 className="subtitle">
+                    By {doc.author} | Published {formatRelative(parsedDate, new Date())}
+                  </h2>
+                </div>
+              </div>
+            </section>
+            {doc.cover &&
+              <amp-img src={doc.cover.image} alt={doc.cover.title} className="image" layout="responsive" />
+            }
+            <section className="section">
+              <div className="content">
+                {this.state.articleHtml}
+              </div>
+            </section>
+          </article>
+          <aside>
+            <section className="section">
+              <div className="align-content">
+                {tagLinks &&
+                  <p className="subtitle">Tags</p>
+                }
+                <div className="tags">
+                  {tagLinks}
+                </div>
+              </div>
+            </section>
+          </aside>
+          <section className="section">
+            <div className="align-content medium-margin-top">
+              <h1 className="title media-left">{data.site.siteMetadata.subscribe.subtitle}</h1>
+              <SignUp/>
+            </div>
+          </section>
+        </Layout>
+        <ArticleFooter metadata={data.site.siteMetadata} document={doc} />
+      </div>
+    )
+  }
+}
+
+export const pageQuery = graphql`
+  query($slug: String!) {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        labels {
+          latestNews
+          search
+          topics
+        }
+        nav {
+          articles
+          topics
+          cms
+        }
+        subscribe {
+          title
+          subtitle
+        }
+      }
+    }
+    googleDocs(document: {path: {eq: $slug}}) {
+        document {
+          author
+          createdTime
+          id
+          name
+          tags
+          og_locale
+          og_title
+          og_description
+          og_image_url
+          og_image_alt
+          og_site_name
+          og_url
+          tw_handle
+          tw_site
+          tw_cardType
+          cover {
+            image
+            alt
+            title
+          }
+        }
+        childMarkdownRemark {
+          excerpt
+          html
+        }
+    }
+  }
+`

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -60,7 +60,6 @@ const canEmbedStreamable = (url) => MATCH_URL_STREAMABLE.test(url);
 
 function isValidUrl(url) {
   let validUrl = urlRegex.test(url);
-  console.log(url, "is it valid? ", validUrl);
   if (!validUrl) {
     return false; // don't bother processing further
   }
@@ -78,7 +77,6 @@ function isValidUrl(url) {
     canEmbedYoutube(url) || 
     canEmbedVimeo(url) );
 
-  console.log(url, "is it supported? ", supportedPlatform);
   return validUrl && supportedPlatform;
 }
 
@@ -108,7 +106,7 @@ const processingInstructions = [
   }
 ];
 
-export default class Posttest extends React.Component {
+export default class Article extends React.Component {
   state = {
     articleHtml: null,
   }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -126,6 +126,7 @@ export default class Posttest extends React.Component {
     let data = this.props.data;
     let doc = data.googleDocs.document;
     let parsedDate = parseISO(doc.createdTime)
+
     let tagLinks;
     if (doc.tags) {
       tagLinks = doc.tags.map((tag, index) => (
@@ -150,7 +151,7 @@ export default class Posttest extends React.Component {
               </div>
             </section>
             {doc.cover &&
-              <img src={doc.cover.image} alt={doc.cover.title} className="image" />
+             <img src={doc.cover.image} alt={doc.cover.title} className="image" />
             }
             <section className="section">
               <div className="content">

--- a/src/templates/subscribe.amp.js
+++ b/src/templates/subscribe.amp.js
@@ -1,15 +1,28 @@
 import React from "react"
+import { Helmet } from 'react-helmet'
 import { graphql } from 'gatsby'
 import ArticleNav from "../components/ArticleNav"
 import SignUp from "../components/SignUp"
 import Layout from "../components/Layout"
 import Footer from "../components/Footer"
+import "../pages/styles.scss"
 
-export default class Subscribe extends React.Component {
+let canonicalUrl;
+export default class SubscribeAMP extends React.Component {
+  componentDidMount() {
+    canonicalUrl = window.location.href.replace("/amp/", "");
+  }
   render() {
     let data = this.props.data;
     return(
       <div>
+        <Helmet
+          htmlAttributes={{ amp: true, lang: 'en' }}
+        >
+          <meta charset="utf-8" />
+          <script async src="https://cdn.ampproject.org/v0.js"></script>
+          <link rel="canonical" href={canonicalUrl} /> // ⚡ Add canonical
+        </Helmet>
         <ArticleNav metadata={data.site.siteMetadata} />
         <Layout title={data.site.siteMetadata.subscribe.title} description={data.site.siteMetadata.subscribe.subtitle}>
           <section className="hero is-primary is-bold">

--- a/src/templates/subscribe.js
+++ b/src/templates/subscribe.js
@@ -1,0 +1,66 @@
+import React from "react"
+import { graphql } from 'gatsby'
+import ArticleNav from "../components/ArticleNav"
+import SignUp from "../components/SignUp"
+import Layout from "../components/Layout"
+import Footer from "../components/Footer"
+import "../pages/styles.scss"
+
+export default class Subscribe extends React.Component {
+  render() {
+    let data = this.props.data;
+    return(
+      <div>
+        <ArticleNav metadata={data.site.siteMetadata} />
+        <Layout title={data.site.siteMetadata.subscribe.title} description={data.site.siteMetadata.subscribe.subtitle}>
+          <section className="hero is-primary is-bold">
+            <div className="hero-body">
+              <div className="container">
+                <h1 className="title">
+                  {data.site.siteMetadata.subscribe.title}
+                </h1>
+                <h2 className="subtitle">
+                  {data.site.siteMetadata.subscribe.subtitle}
+                </h2>
+              </div>
+            </div>
+          </section>
+          <section className="section">
+            <SignUp/> 
+          </section>
+          
+        </Layout>
+        <Footer post_type="page" metadata={data.site.siteMetadata} />
+      </div>
+    );
+  }
+}
+
+export const query = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        labels {
+          latestNews
+          search
+          topics
+        }
+        nav {
+          articles
+          topics
+          cms
+        }
+        subscribe {
+          title
+          subtitle
+        }
+      }
+    }
+}`

--- a/src/templates/tag.amp.js
+++ b/src/templates/tag.amp.js
@@ -1,0 +1,78 @@
+import React from "react"
+import { Helmet } from 'react-helmet'
+import { graphql } from "gatsby"
+import ArticleNav from "../components/ArticleNav"
+import ArticleLink from "../components/ArticleLink"
+import Layout from "../components/Layout"
+import Footer from "../components/Footer"
+import "../pages/styles.scss"
+
+let canonicalUrl;
+class TagAMP extends React.Component {
+  componentDidMount() {
+    canonicalUrl = window.location.href.replace("/amp/", "");
+  }
+  render() {
+    let data = this.props.data;
+    let tagHeader = "Articles tagged: " + this.props.pageContext.tag;
+    
+    return (
+      <div>
+        <Helmet
+          htmlAttributes={{ amp: true, lang: 'en' }}
+        >
+          <meta charset="utf-8" />
+          <script async src="https://cdn.ampproject.org/v0.js"></script>
+          <link rel="canonical" href={canonicalUrl} /> // ⚡ Add canonical
+        </Helmet>
+        <ArticleNav metadata={data.site.siteMetadata} />
+        <Layout>
+          <section className="section">
+            <h3 className="title is-size-4 is-bold-light">{tagHeader}</h3>
+            {data.allGoogleDocs.nodes.map(({ document, childMarkdownRemark }, index) => (
+              <ArticleLink key={document.path} document={document} excerpt={childMarkdownRemark.excerpt} /> 
+            ))}
+          </section>
+        </Layout>
+        <Footer post_type="tag" metadata={data.site.siteMetadata} />
+      </div>
+    )
+  }
+}
+
+export default TagAMP;
+
+export const tagPageQuery = graphql`
+  query TagAMPPage($tag: String) {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        nav {
+          articles
+          topics
+          cms
+        }
+      }
+    }
+    allGoogleDocs(filter: {document: {tags: {in: [$tag]}}}) {
+      nodes {
+        document {
+          id
+          name
+          path
+          createdTime
+          author
+        }
+        childMarkdownRemark {
+          excerpt(truncate: true, format: PLAIN, pruneLength: 100)
+        }
+      }
+    }
+  }
+`

--- a/src/templates/topics.amp.js
+++ b/src/templates/topics.amp.js
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react"
+import { Helmet } from 'react-helmet'
+import _ from 'lodash'
+import { Link, graphql } from "gatsby"
+import ArticleNav from "../components/ArticleNav"
+import Layout from "../components/Layout"
+import Footer from "../components/Footer"
+import "../pages/styles.scss"
+
+export default function TopicsIndexAMP({ data }) {
+  const [canonicalUrl, setCanonicalUrl] = useState('')
+  useEffect(() => {
+    setCanonicalUrl(window.location.href.replace("/amp/", ""));
+  }, []);
+
+  let tags = [];
+  data.allGoogleDocs.nodes.forEach(({document}, index) => {
+    tags = tags.concat(document.tags);
+  })
+  // remove any null tags
+  tags = tags.filter(function (el) {
+    return el != null;
+  });
+  tags = _.uniq(tags).sort();
+  const tagLinks = tags.map( (tag, index) => (
+    <li key={index}><Link to={`/topics/${_.kebabCase(tag)}`}>{_.startCase(tag)}</Link></li>
+  ));
+
+  return(
+    <div>
+        <Helmet
+          htmlAttributes={{ amp: true, lang: 'en' }}
+        >
+          <meta charset="utf-8" />
+          <script async src="https://cdn.ampproject.org/v0.js"></script>
+          <link rel="canonical" href={canonicalUrl} /> // ⚡ Add canonical
+        </Helmet>
+      <ArticleNav metadata={data.site.siteMetadata} />
+      <Layout>
+        <section className="section">
+          <h3 className="title is-size-4 is-bold-light">Topics</h3>
+          <aside className="menu">
+            <ul className="menu-list">
+              {tagLinks}
+            </ul>
+          </aside>
+        </section>
+      </Layout>
+      <Footer post_type="tag" metadata={data.site.siteMetadata} />
+    </div>
+  )
+}
+
+export const query = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        labels {
+          latestNews
+          search
+          topics
+        }
+        nav {
+          articles
+          topics
+          cms
+        }
+      }
+    }
+    allGoogleDocs(filter: {document: {breadcrumb: {nin: "Drafts"}}}) {
+      nodes {
+        document {
+          name
+          tags
+        }
+      }
+    }
+  }`

--- a/src/templates/topics.js
+++ b/src/templates/topics.js
@@ -4,9 +4,9 @@ import { Link, graphql } from "gatsby"
 import ArticleNav from "../components/ArticleNav"
 import Layout from "../components/Layout"
 import Footer from "../components/Footer"
-import "./styles.scss"
+import "../pages/styles.scss"
 
-export default function HomePage({ data }) {
+export default function TopicsIndex({ data }) {
   let tags = [];
   data.allGoogleDocs.nodes.forEach(({document}, index) => {
     tags = tags.concat(document.tags);


### PR DESCRIPTION
issues: #73, #93 

this PR adds AMP versions of all pages except the 404 page. it also fixes an issue I somehow hadn't noticed til today that's probably the result of all the fancy footwork that went into making the article pages support embeds - see issue #93 for a screenshot. 

short version is we're no longer using an AMP plugin for gatsby. I think this is good because: less complexity and magic, more control of what gets rendered to pages. The plugin also didn't fully support all AMP components. 

all urls on the tinynewsco app are now created in gatsby-node.js with the exception of the homepage, which is a "dynamic" page in `src/pages`. I am now thinking we might need to create an AMP version of it and move the rendering to `gatsby-node.js` though. I'll open separate PR for the homepage.