### PR TITLE
Add coral to article pages; properly set canonical url

### DIFF
--- a/src/components/ArticleFooter.js
+++ b/src/components/ArticleFooter.js
@@ -7,7 +7,7 @@ class ArticleFooter extends React.Component {
   render () {
     return (
         <footer className="footer">
-          <Coral post_id={this.props.document.id} />
+          <Coral post_id={this.props.document.id} storyURL={this.props.canonical} />
           <Pico post_id={this.props.document.id} post_type="article" tags={this.props.document.tags} article={true} />
           <div className="content has-text-centered">
             <p>

--- a/src/components/ArticleFooter.js
+++ b/src/components/ArticleFooter.js
@@ -1,11 +1,13 @@
 
 import React from "react"
+import Coral from "./Coral"
 import Pico from "./Pico"
 
 class ArticleFooter extends React.Component {
   render () {
     return (
         <footer className="footer">
+          <Coral post_id={this.props.document.id} />
           <Pico post_id={this.props.document.id} post_type="article" tags={this.props.document.tags} article={true} />
           <div className="content has-text-centered">
             <p>

--- a/src/components/Coral.js
+++ b/src/components/Coral.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+
+class Coral extends Component {
+  componentDidMount(){
+    const script=document.createElement('script')
+    script.id="loadCoral"
+    script.src="/coral.js"
+    script.async=true;
+    this.instance.appendChild(script)
+
+    document.getElementById("loadCoral").addEventListener('load', () => {
+      console.log("Coral is loaded");
+    });
+  }
+  
+  render() {
+    return (
+      <div ref={el => (this.instance = el)} id="coral_thread"></div>
+    )
+  }
+}
+
+export default Coral;

--- a/src/components/Coral.js
+++ b/src/components/Coral.js
@@ -10,6 +10,8 @@ class Coral extends Component {
 
     document.getElementById("loadCoral").addEventListener('load', () => {
       console.log("Coral is loaded");
+      console.log("storyUrl: ", this.props.storyURL);
+      const storyURL = this.props.storyURL;
     });
   }
   

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -7,6 +7,7 @@ export default function Layout(props) {
       <GatsbySeo
       title={props.og_title}
       description={props.og_description}
+      canonical={props.canonical}
       openGraph={{
         title: props.og_title,
         description: props.og_description,

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -180,7 +180,7 @@ export default class Posttest extends React.Component {
             </div>
           </section>
         </Layout>
-        <ArticleFooter metadata={data.site.siteMetadata} document={doc} />
+        <ArticleFooter metadata={data.site.siteMetadata} document={doc} canonical={this.state.canonical} />
       </div>
     )
   }

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { Helmet } from 'react-helmet'
 import _ from 'lodash'
 import { graphql, Link } from "gatsby"
 import { parseISO, formatRelative } from 'date-fns'
@@ -60,7 +61,6 @@ const canEmbedStreamable = (url) => MATCH_URL_STREAMABLE.test(url);
 
 function isValidUrl(url) {
   let validUrl = urlRegex.test(url);
-  console.log(url, "is it valid? ", validUrl);
   if (!validUrl) {
     return false; // don't bother processing further
   }
@@ -78,7 +78,6 @@ function isValidUrl(url) {
     canEmbedYoutube(url) || 
     canEmbedVimeo(url) );
 
-  console.log(url, "is it supported? ", supportedPlatform);
   return validUrl && supportedPlatform;
 }
 
@@ -111,11 +110,15 @@ const processingInstructions = [
 export default class Posttest extends React.Component {
   state = {
     articleHtml: null,
+    canonical: '',
   }
   componentDidMount() {
+    let canonical = window.location.href; // this must be set correctly for Coral to load, also for SEO
+
     let updatedHtml = htmlParser.parseWithInstructions(this.props.data.googleDocs.childMarkdownRemark.html, isValidNode, processingInstructions);
     this.setState({
       articleHtml: updatedHtml,
+      canonical: canonical,
     })
     getCLS(sendToGoogleAnalytics);
     getFID(sendToGoogleAnalytics);
@@ -135,7 +138,7 @@ export default class Posttest extends React.Component {
     return (
       <div id="article-container">
         <ArticleNav metadata={data.site.siteMetadata} />
-        <Layout title={doc.name} description={data.googleDocs.childMarkdownRemark.excerpt} {...doc}>
+        <Layout title={doc.name} description={data.googleDocs.childMarkdownRemark.excerpt} canonical={this.state.canonical} {...doc}>
           <article>
             <section className="hero is-bold">
               <div className="hero-body">
@@ -216,6 +219,7 @@ export const pageQuery = graphql`
           createdTime
           id
           name
+          path
           tags
           og_locale
           og_title

--- a/static/coral.js
+++ b/static/coral.js
@@ -1,21 +1,23 @@
 (function() {
     let d = document, s = d.createElement('script');
-    var url = 'localhost:3000';
-    s.src = '//' + url + '/assets/js/embed.js';
+    let storyURL = window.location.href;
+    // s.src = '//' + url + '/assets/js/embed.js';
+    s.src = 'https://coral-talk-news-catalyst.herokuapp.com/assets/js/embed.js';
     s.async = false;
     s.defer = true;
     s.onload = function() {
         Coral.createStreamEmbed({
             id: "coral_thread",
             autoRender: true,
-            rootURL: '//' + url,
+            // rootURL: '//' + url,
+            rootURL: 'https://coral-talk-news-catalyst.herokuapp.com',
             // Uncomment these lines and replace with the ID of the
             // story's ID and URL from your CMS to provide the
             // tightest integration. Refer to our documentation at
             // https://docs.coralproject.net for all the configuration
             // options.
             // storyID: '${storyID}',
-            // storyURL: '${storyURL}',
+            storyURL: storyURL,
         });
     };
     (d.head || d.body).appendChild(s);

--- a/static/coral.js
+++ b/static/coral.js
@@ -1,0 +1,22 @@
+(function() {
+    let d = document, s = d.createElement('script');
+    var url = 'localhost:3000';
+    s.src = '//' + url + '/assets/js/embed.js';
+    s.async = false;
+    s.defer = true;
+    s.onload = function() {
+        Coral.createStreamEmbed({
+            id: "coral_thread",
+            autoRender: true,
+            rootURL: '//' + url,
+            // Uncomment these lines and replace with the ID of the
+            // story's ID and URL from your CMS to provide the
+            // tightest integration. Refer to our documentation at
+            // https://docs.coralproject.net for all the configuration
+            // options.
+            // storyID: '${storyID}',
+            // storyURL: '${storyURL}',
+        });
+    };
+    (d.head || d.body).appendChild(s);
+})();


### PR DESCRIPTION
Issue #64 - Integrate Coral

This PR starts the work of integrating Coral comments on a tiny news site.

Coral is installed and running on Heroku at https://coral-talk-news-catalyst.herokuapp.com/admin/dashboard. The setup for the tinynewsdemo site is similar to the Pico setup - there's a Coral.js component that includes a coral.js script found in `/static/` that loads Coral on a page. This is only done on article pages.

This PR also includes some small changes to the `canonical` link tag on the article page. Why? Because if the canonical URL differs from the actual URL, Coral won't load. I discovered that after a long walk through [content security policy and iframes info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) (link goes to only the first page of that journey). This made me realize that our canonical link tags were totally wrong (all were set to the homepage) on articles, which is bad for SEO and I imagine for AMP.

This canonical link work for AMP has been taken care of :) ~The canonical link will have to be modified slightly in the AMP template and passed onto the `<Layout>` component correctly as a prop; that work is in another open PR now though.~