### PR TITLE
Section links on homepage

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -161,6 +161,9 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       actions.createPage({
         path: "/",
         component: path.resolve(`./src/templates/homepage.js`),
+        context: {
+          sections,
+        }
       })
       console.log("creating homepage at /")
       
@@ -168,8 +171,11 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       actions.createPage({
         path: "/amp/",
         component: path.resolve(`./src/templates/homepage.amp.js`),
+        context: {
+          sections,
+        }
       })
-      console.log("creating homepage at /amp/")
+      console.log("creating homepage for AMP at /amp/")
   })
 
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -156,6 +156,20 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         component: path.resolve(`./src/templates/subscribe.amp.js`),
       })
       console.log("creating newsletter subscribe page for AMP at /subscribe/amp/")
+
+      // finally, create homepage
+      actions.createPage({
+        path: "/",
+        component: path.resolve(`./src/templates/homepage.js`),
+      })
+      console.log("creating homepage at /")
+      
+      // and, create the AMP version of the homepage
+      actions.createPage({
+        path: "/amp/",
+        component: path.resolve(`./src/templates/homepage.amp.js`),
+      })
+      console.log("creating homepage at /amp/")
   })
 
 }

--- a/src/pages/tinycms/edit.js
+++ b/src/pages/tinycms/edit.js
@@ -1,5 +1,6 @@
 
 import React from "react"
+import { graphql } from 'gatsby'
 import Layout from "../../components/Layout"
 import GoogleEdit from "../../components/GoogleEdit"
 

--- a/src/templates/homepage.amp.js
+++ b/src/templates/homepage.amp.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react"
 import _ from 'lodash'
+import { Helmet } from 'react-helmet'
 import { Link, graphql } from "gatsby"
 import {getCLS, getFID, getLCP} from 'web-vitals';
 import Layout from "../components/Layout"
@@ -11,9 +12,12 @@ import HomepageSearchPanel from "../components/HomepageSearchPanel"
 import sendToGoogleAnalytics from "../utils/vitals"
 import "../pages/styles.scss"
 
+
 export default function HomePageAMP({ data, pageContext }) {
   const [query, setQuery] = useState('')
+  let canonicalURL;
   useEffect(() => {
+    canonicalURL = window.location.href.replace("/amp/", "");
     getCLS(sendToGoogleAnalytics);
     getFID(sendToGoogleAnalytics);
     getLCP(sendToGoogleAnalytics);
@@ -43,6 +47,13 @@ export default function HomePageAMP({ data, pageContext }) {
 
   return(
     <div>
+        <Helmet
+          htmlAttributes={{ amp: true, lang: 'en' }}
+        >
+          <meta charset="utf-8" />
+          <script async src="https://cdn.ampproject.org/v0.js"></script>
+          <link rel="canonical" href={canonicalURL} /> // ⚡ Add canonical
+        </Helmet>
       <ArticleNav metadata={data.site.siteMetadata} tags={tags} sections={sections} />
       <Layout title={data.site.siteMetadata.title} description={data.site.siteMetadata.description}>
         <section className="hero is-dark is-bold">

--- a/src/templates/homepage.amp.js
+++ b/src/templates/homepage.amp.js
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from "react"
+import _ from 'lodash'
+import { Link, graphql } from "gatsby"
+import {getCLS, getFID, getLCP} from 'web-vitals';
+import Layout from "../components/Layout"
+import Footer from "../components/Footer"
+import ArticleLink from "../components/ArticleLink"
+import FeaturedArticleLink from "../components/FeaturedArticleLink"
+import ArticleNav from "../components/ArticleNav"
+import HomepageSearchPanel from "../components/HomepageSearchPanel"
+import sendToGoogleAnalytics from "../utils/vitals"
+import "../pages/styles.scss"
+
+export default function HomePageAMP({ data, pageContext }) {
+  const [query, setQuery] = useState('')
+  useEffect(() => {
+    getCLS(sendToGoogleAnalytics);
+    getFID(sendToGoogleAnalytics);
+    getLCP(sendToGoogleAnalytics);
+  }, []);
+
+  let sections = pageContext.sections;
+  let allArticles = data.allGoogleDocs.nodes;
+  let featuredArticles = allArticles.filter(node => node.document.featured);
+  let unfeaturedArticles = allArticles.filter(node => !node.document.featured);
+
+  let tags = [];
+  allArticles.forEach(({document}, index) => {
+    tags = tags.concat(document.tags);
+  })
+  tags = _.uniq(tags).sort();
+  // remove any null tags
+  tags = tags.filter(function (el) {
+    return el != null;
+  });
+
+  const tagLinks = tags.map(tag => (
+    <Link key={tag} to={`/topics/${tag}`} className="panel-block is-active">
+      {_.startCase(tag)}
+    </Link>
+  ));
+
+
+  return(
+    <div>
+      <ArticleNav metadata={data.site.siteMetadata} tags={tags} sections={sections} />
+      <Layout title={data.site.siteMetadata.title} description={data.site.siteMetadata.description}>
+        <section className="hero is-dark is-bold">
+          <div className="hero-body">
+            <div className="container">
+              <h1 className="title">
+                {data.site.siteMetadata.title}
+              </h1>
+              <h2 className="subtitle">
+                {data.site.siteMetadata.description}
+              </h2>
+            </div>
+          </div>
+        </section>
+        <div className="featured-article">
+          {featuredArticles.map(({ document, childMarkdownRemark }, index) => (
+            <FeaturedArticleLink key={document.path} document={document} excerpt={childMarkdownRemark.excerpt} /> 
+          ))}
+        </div>
+        <section className="section">
+          <div className="columns">
+            <div className="column is-four-fifths">
+              {unfeaturedArticles.map(({ document, childMarkdownRemark }, index) => (
+                <ArticleLink key={document.path} document={document} excerpt={childMarkdownRemark.excerpt} /> 
+              ))}
+            </div>
+            <div className="column">
+              <HomepageSearchPanel metadata={data.site.siteMetadata} query={query} setQuery={setQuery} />
+              <nav className="panel">
+                <p className="panel-heading">
+                  {data.site.siteMetadata.labels.topics}
+                </p>
+                {tagLinks}
+              </nav>
+            </div>
+          </div>
+        </section>
+        
+      </Layout>
+      <Footer post_type="home" metadata={data.site.siteMetadata} />
+    </div>
+  )
+}
+
+export const query = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+        shortName
+        description
+        siteUrl
+        footerTitle
+        footerBylineName
+        footerBylineLink
+        labels {
+          latestNews
+          search
+          topics
+        }
+        nav {
+          articles
+          topics
+          cms
+        }
+      }
+    }
+
+    allGoogleDocs(filter: {document: {breadcrumb: {nin: "Drafts"}}}, sort: {fields: document___author, order: DESC}) {
+        nodes {
+            document {
+              author
+              createdTime
+              featured
+              name
+              path
+              tags
+              cover {
+                image
+              }
+            }
+            childMarkdownRemark {
+              excerpt(truncate: true, format: PLAIN, pruneLength: 100)
+            }
+        }
+    }
+  }`

--- a/src/templates/homepage.js
+++ b/src/templates/homepage.js
@@ -9,10 +9,9 @@ import FeaturedArticleLink from "../components/FeaturedArticleLink"
 import ArticleNav from "../components/ArticleNav"
 import HomepageSearchPanel from "../components/HomepageSearchPanel"
 import sendToGoogleAnalytics from "../utils/vitals"
+import "../pages/styles.scss"
 
-import "./styles.scss"
-
-export default function HomePage({ data }) {
+export default function HomePage({ data, pageContext }) {
   const [query, setQuery] = useState('')
   useEffect(() => {
     getCLS(sendToGoogleAnalytics);
@@ -20,6 +19,7 @@ export default function HomePage({ data }) {
     getLCP(sendToGoogleAnalytics);
   }, []);
 
+  let sections = pageContext.sections;
   let allArticles = data.allGoogleDocs.nodes;
   let featuredArticles = allArticles.filter(node => node.document.featured);
   let unfeaturedArticles = allArticles.filter(node => !node.document.featured);
@@ -43,7 +43,7 @@ export default function HomePage({ data }) {
 
   return(
     <div>
-      <ArticleNav metadata={data.site.siteMetadata} tags={tags} />
+      <ArticleNav metadata={data.site.siteMetadata} tags={tags} sections={sections} />
       <Layout title={data.site.siteMetadata.title} description={data.site.siteMetadata.description}>
         <section className="hero is-dark is-bold">
           <div className="hero-body">


### PR DESCRIPTION
(closes issue #95) This PR adds the section links, as defined in the settings editor / `settings` google doc, to the homepage nav. 

I had to make a couple changes:

* first, I moved the homepage from being a "gatsby page" (under `src/pages/index.js`) to being published via `gatsby-node.js` out of a template (`src/templates/homepage.js`)
* I did the same for an AMP version (`src/templates/homepage.amp.js`), with some AMP-specific required additions
* I pass the site sections as `pageContext` (https://www.gatsbyjs.org/docs/creating-and-modifying-pages/#pass-context-to-pages)
* These sections are then passed to the `ArticleNav.js` as props; that component was already setup to include section links if they exist